### PR TITLE
Implement modular agent execution and logging

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -3,6 +3,7 @@ const cors = require('cors');
 const dotenv = require('dotenv');
 const fs = require('fs');
 const path = require('path');
+const loadAgents = require('./loadAgents');
 
 // Load environment variables from .env if present
 dotenv.config();
@@ -24,23 +25,33 @@ function ensureLogFile() {
   }
 }
 
+function readLogs() {
+  ensureLogFile();
+  try {
+    return JSON.parse(fs.readFileSync(LOG_FILE, 'utf8'));
+  } catch (err) {
+    return [];
+  }
+}
+
+function writeLogs(logs) {
+  fs.writeFileSync(LOG_FILE, JSON.stringify(logs, null, 2));
+}
+
+function appendLog(entry) {
+  const logs = readLogs();
+  logs.push(entry);
+  writeLogs(logs);
+}
+
 // Append request info to log file
 function logRequest(req) {
-  ensureLogFile();
-  let logs = [];
-  try {
-    logs = JSON.parse(fs.readFileSync(LOG_FILE, 'utf8'));
-  } catch (err) {
-    // If parsing fails, reset logs
-    logs = [];
-  }
-  logs.push({
+  appendLog({
     timestamp: new Date().toISOString(),
     method: req.method,
     url: req.originalUrl,
     body: req.body,
   });
-  fs.writeFileSync(LOG_FILE, JSON.stringify(logs, null, 2));
 }
 
 // Request logging middleware
@@ -50,56 +61,54 @@ app.use((req, res, next) => {
 });
 
 // Object to hold loaded agents keyed by file name (without extension)
-const registeredAgents = {};
-
-// Load agents from /agents directory
-function loadAgents() {
-  const agentsDir = path.join(__dirname, '..', 'agents');
-  if (!fs.existsSync(agentsDir)) return;
-
-  fs.readdirSync(agentsDir).forEach((file) => {
-    const modulePath = path.join(agentsDir, file);
-    if (fs.statSync(modulePath).isFile() && file.endsWith('.js')) {
-      const agentName = path.basename(file, '.js');
-      try {
-        const agent = require(modulePath);
-        if (agent && typeof agent.run === 'function') {
-          registeredAgents[agentName] = agent;
-          console.log(`Loaded agent: ${agentName}`);
-        } else {
-          console.warn(`Agent ${agentName} does not export a run() function`);
-        }
-      } catch (err) {
-        console.error(`Failed to load agent ${agentName}:`, err);
-      }
-    }
-  });
-}
+const registeredAgents = loadAgents();
 
 // Endpoint to execute a specific agent
 app.post('/run-agent', async (req, res) => {
   const { agent: agentName, input } = req.body || {};
 
   if (!agentName) {
+    appendLog({
+      timestamp: new Date().toISOString(),
+      agent: agentName,
+      input,
+      error: 'Agent name not provided',
+    });
     return res.status(400).json({ error: 'Agent name not provided' });
   }
 
   const agent = registeredAgents[agentName];
 
   if (!agent) {
+    appendLog({
+      timestamp: new Date().toISOString(),
+      agent: agentName,
+      input,
+      error: `Agent '${agentName}' not found`,
+    });
     return res.status(404).json({ error: `Agent '${agentName}' not found` });
   }
 
   try {
     const result = await Promise.resolve(agent.run(input));
+    appendLog({
+      timestamp: new Date().toISOString(),
+      agent: agentName,
+      input,
+      output: result,
+    });
     return res.json({ result });
   } catch (err) {
     console.error(`Agent '${agentName}' failed to run:`, err);
+    appendLog({
+      timestamp: new Date().toISOString(),
+      agent: agentName,
+      input,
+      error: err.message,
+    });
     return res.status(500).json({ error: 'Agent execution failed', details: err.message });
   }
 });
-
-loadAgents();
 
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {

--- a/functions/loadAgents.js
+++ b/functions/loadAgents.js
@@ -1,0 +1,36 @@
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Load all agents from the ../agents directory.
+ * Returns an object with agent names as keys and agent modules as values.
+ */
+function loadAgents() {
+  const agents = {};
+  const agentsDir = path.join(__dirname, '..', 'agents');
+  if (!fs.existsSync(agentsDir)) {
+    return agents;
+  }
+
+  fs.readdirSync(agentsDir).forEach((file) => {
+    const modulePath = path.join(agentsDir, file);
+    if (fs.statSync(modulePath).isFile() && file.endsWith('.js')) {
+      const agentName = path.basename(file, '.js');
+      try {
+        const agent = require(modulePath);
+        if (agent && typeof agent.run === 'function') {
+          agents[agentName] = agent;
+          console.log(`Loaded agent: ${agentName}`);
+        } else {
+          console.warn(`Agent ${agentName} does not export a run() function`);
+        }
+      } catch (err) {
+        console.error(`Failed to load agent ${agentName}:`, err);
+      }
+    }
+  });
+
+  return agents;
+}
+
+module.exports = loadAgents;


### PR DESCRIPTION
## Summary
- support modular agent loading via new `loadAgents` module
- append generic log entries and log agent output/errors
- update `/run-agent` endpoint to return errors when agent is missing or fails

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6854757930088323b98686a4ba9f2999