### PR TITLE
Enable sequential agent workflow in gallery

### DIFF
--- a/frontend/AgentsGallery.jsx
+++ b/frontend/AgentsGallery.jsx
@@ -23,8 +23,10 @@ const agents = [
 
 export default function AgentsGallery() {
   const [selectedAgent, setSelectedAgent] = useState(null);
+  const [selectedAgents, setSelectedAgents] = useState([]);
   const [inputValue, setInputValue] = useState("");
   const [output, setOutput] = useState(null);
+  const [workflowOutput, setWorkflowOutput] = useState([]);
 
   const runDemo = async () => {
     if (!selectedAgent) return;
@@ -40,13 +42,54 @@ export default function AgentsGallery() {
     setOutput(result.response || result.error);
   };
 
+  const toggleAgent = (agent) => {
+    setWorkflowOutput([]);
+    setSelectedAgents((prev) =>
+      prev.some((a) => a.id === agent.id)
+        ? prev.filter((a) => a.id !== agent.id)
+        : [...prev, agent]
+    );
+  };
+
+  const runWorkflow = async () => {
+    const outputs = [];
+    for (const agent of selectedAgents) {
+      try {
+        const res = await fetch("/run-agent", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            agent: agent.id,
+            input: { text: inputValue || "Test input" },
+          }),
+        });
+        const result = await res.json();
+        outputs.push({
+          agent: agent.name,
+          output: result.result || result.response || result.error,
+        });
+      } catch (err) {
+        outputs.push({ agent: agent.name, output: err.message });
+      }
+    }
+    setWorkflowOutput(outputs);
+  };
+
   return (
     <div className="p-6 text-white">
       <h1 className="text-4xl font-bold mb-8">View Our Agents</h1>
       <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
         {agents.map(agent => (
           <div key={agent.id} className="bg-white/10 backdrop-blur p-6 rounded-xl border border-white/20">
-            <h2 className="text-xl font-semibold mb-2">{agent.name}</h2>
+            <div className="flex items-start justify-between mb-2">
+              <h2 className="text-xl font-semibold">{agent.name}</h2>
+              <input
+                type="checkbox"
+                checked={selectedAgents.some(a => a.id === agent.id)}
+                onChange={() => toggleAgent(agent)}
+                className="form-checkbox h-4 w-4 text-blue-500"
+              />
+            </div>
             <p className="text-gray-300 mb-2">{agent.description}</p>
             <div className="flex flex-wrap gap-2 mb-4">
               {agent.tags.map(tag => (
@@ -70,6 +113,17 @@ export default function AgentsGallery() {
           </div>
         ))}
       </div>
+
+      {selectedAgents.length > 0 && (
+        <div className="mt-6">
+          <button
+            onClick={runWorkflow}
+            className="bg-purple-500 hover:bg-purple-600 text-white px-4 py-2 rounded"
+          >
+            Run Workflow
+          </button>
+        </div>
+      )}
 
       {selectedAgent && (
         <div className="mt-12 p-6 bg-white/10 rounded-xl border border-white/20">
@@ -101,6 +155,20 @@ export default function AgentsGallery() {
               {typeof output === "string" ? output : JSON.stringify(output, null, 2)}
             </div>
           )}
+        </div>
+      )}
+
+      {workflowOutput.length > 0 && (
+        <div className="mt-12 p-6 bg-white/10 rounded-xl border border-white/20">
+          <h2 className="text-2xl font-semibold mb-4">Workflow Output</h2>
+          {workflowOutput.map(res => (
+            <div key={res.agent} className="mb-6">
+              <h3 className="text-lg font-semibold mb-2">{res.agent}</h3>
+              <pre className="bg-black/30 p-4 rounded text-sm text-green-300 whitespace-pre-wrap">
+                {typeof res.output === "string" ? res.output : JSON.stringify(res.output, null, 2)}
+              </pre>
+            </div>
+          ))}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- allow selecting multiple agents with checkboxes
- add a Run Workflow button
- execute agents sequentially and show combined output

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68548430560c8323bc605c69bb5e5db1