### PR TITLE
Add AgentTracker and session tracking

### DIFF
--- a/frontend/AgentTracker.jsx
+++ b/frontend/AgentTracker.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { CheckCircle, Loader2 } from 'lucide-react';
+
+const AgentTracker = ({ steps = [], currentStep = 0, status = [] }) => {
+  const progress = steps.length > 1 ? (status.filter(s => s === 'completed').length / steps.length) * 100 : 0;
+
+  return (
+    <div className="w-full space-y-4">
+      <div className="flex justify-between">
+        {steps.map((step, idx) => {
+          const state = status[idx] || 'pending';
+          const color = state === 'completed' ? 'text-green-500' : state === 'active' ? 'text-blue-500' : 'text-gray-400';
+          return (
+            <div key={idx} className="flex-1 flex flex-col items-center">
+              {state === 'completed' && <CheckCircle className={`w-5 h-5 mb-1 ${color}`} />}
+              {state === 'active' && <Loader2 className={`w-5 h-5 mb-1 animate-spin ${color}`} />}
+              {state === 'pending' && <div className="w-5 h-5 mb-1 rounded-full bg-gray-300" />}
+              <span className={`text-xs ${color}`}>{step}</span>
+            </div>
+          );
+        })}
+      </div>
+      <div className="w-full bg-gray-200 h-2 rounded-full">
+        <div className="bg-blue-500 h-2 rounded-full" style={{ width: `${progress}%` }} />
+      </div>
+    </div>
+  );
+};
+
+export default AgentTracker;


### PR DESCRIPTION
## Summary
- create `AgentTracker` React component for showing agent progress
- update `LandingPage.jsx` to use `AgentTracker` and poll backend for session status
- enhance Express backend with session status tracking and a new `/status/:sessionId` endpoint

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68548894b1588323bc4abc246510d09e