### PR TITLE
Improve mobile UI for AgentTracker

### DIFF
--- a/frontend/AgentTracker.jsx
+++ b/frontend/AgentTracker.jsx
@@ -6,16 +6,16 @@ const AgentTracker = ({ steps = [], currentStep = 0, status = [] }) => {
 
   return (
     <div className="w-full space-y-4">
-      <div className="flex justify-between">
+      <div className="flex flex-col sm:flex-row sm:justify-between overflow-x-auto space-y-2 sm:space-y-0">
         {steps.map((step, idx) => {
           const state = status[idx] || 'pending';
           const color = state === 'completed' ? 'text-green-500' : state === 'active' ? 'text-blue-500' : 'text-gray-400';
           return (
-            <div key={idx} className="flex-1 flex flex-col items-center">
-              {state === 'completed' && <CheckCircle className={`w-5 h-5 mb-1 ${color}`} />}
-              {state === 'active' && <Loader2 className={`w-5 h-5 mb-1 animate-spin ${color}`} />}
-              {state === 'pending' && <div className="w-5 h-5 mb-1 rounded-full bg-gray-300" />}
-              <span className={`text-xs ${color}`}>{step}</span>
+            <div key={idx} className="flex-shrink-0 sm:flex-1 flex flex-col items-center">
+              {state === 'completed' && <CheckCircle className={`w-5 h-5 mb-1 sm:mb-2 ${color}`} />}
+              {state === 'active' && <Loader2 className={`w-5 h-5 mb-1 sm:mb-2 animate-spin ${color}`} />}
+              {state === 'pending' && <div className="w-5 h-5 mb-1 sm:mb-2 rounded-full bg-gray-300" />}
+              <span className={`text-xs sm:text-sm whitespace-nowrap ${color}`}>{step}</span>
             </div>
           );
         })}


### PR DESCRIPTION
## Summary
- adjust AgentTracker layout for mobile screens
- maintain progress icons vertically stacked on small devices and add responsive font sizes
- enable horizontal scrolling when step labels overflow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68548a6f0b5083239ad34d46cc3c1ef9