### PR TITLE
Add admin dashboard MVP

### DIFF
--- a/frontend/AdminDashboard.jsx
+++ b/frontend/AdminDashboard.jsx
@@ -1,0 +1,92 @@
+import React, { useEffect, useState } from 'react';
+
+export default function AdminDashboard() {
+  const [sessions, setSessions] = useState([]);
+  const [days, setDays] = useState(7);
+
+  const fetchSessions = async () => {
+    try {
+      const res = await fetch(`/logs/sessions?days=${days}`, {
+        headers: { 'x-admin-key': localStorage.getItem('adminKey') || '' }
+      });
+      const data = await res.json();
+      if (!data.error) setSessions(data);
+    } catch {
+      setSessions([]);
+    }
+  };
+
+  useEffect(() => { fetchSessions(); }, [days]);
+
+  const downloadSession = async id => {
+    try {
+    const res = await fetch(`/logs/sessions/${id}`, {
+      headers: { 'x-admin-key': localStorage.getItem('adminKey') || '' }
+    });
+    const blob = await res.blob();
+    const url = window.URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${id}.json`;
+    a.click();
+    window.URL.revokeObjectURL(url);
+    } catch {}
+  };
+
+  return (
+    <div className="p-6 text-white">
+      <h1 className="text-2xl font-bold mb-4">Admin Dashboard</h1>
+      <div className="mb-4 space-x-2">
+        <label>
+          Last
+          <input
+            type="number"
+            value={days}
+            onChange={e => setDays(e.target.value)}
+            className="mx-2 w-16 p-1 rounded text-black"
+          />
+          days
+        </label>
+        <button
+          onClick={fetchSessions}
+          className="bg-blue-500 text-white px-2 py-1 rounded"
+        >
+          Refresh
+        </button>
+      </div>
+      <div className="overflow-auto">
+        <table className="min-w-full text-sm">
+          <thead>
+            <tr className="text-left">
+              <th className="p-2">Date</th>
+              <th className="p-2">Name</th>
+              <th className="p-2">Email</th>
+              <th className="p-2">Agents</th>
+              <th className="p-2">Status</th>
+              <th className="p-2">Download</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sessions.map(s => (
+              <tr key={s.sessionId} className="border-t border-white/20">
+                <td className="p-2">{new Date(s.date).toLocaleString()}</td>
+                <td className="p-2">{s.name || '-'}</td>
+                <td className="p-2">{s.email || '-'}</td>
+                <td className="p-2">{(s.agents || []).join(', ')}</td>
+                <td className="p-2">{s.status}</td>
+                <td className="p-2">
+                  <button
+                    onClick={() => downloadSession(s.sessionId)}
+                    className="text-blue-400 underline"
+                  >
+                    JSON
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/frontend/admin/dashboard.jsx
+++ b/frontend/admin/dashboard.jsx
@@ -1,0 +1,92 @@
+import React, { useEffect, useState } from 'react';
+
+export default function AdminDashboard() {
+  const [sessions, setSessions] = useState([]);
+  const [days, setDays] = useState(7);
+
+  const fetchSessions = async () => {
+    try {
+      const res = await fetch(`/logs/sessions?days=${days}`, {
+        headers: { 'x-admin-key': localStorage.getItem('adminKey') || '' }
+      });
+      const data = await res.json();
+      if (!data.error) setSessions(data);
+    } catch {
+      setSessions([]);
+    }
+  };
+
+  useEffect(() => { fetchSessions(); }, [days]);
+
+  const downloadSession = async id => {
+    try {
+    const res = await fetch(`/logs/sessions/${id}`, {
+      headers: { 'x-admin-key': localStorage.getItem('adminKey') || '' }
+    });
+    const blob = await res.blob();
+    const url = window.URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${id}.json`;
+    a.click();
+    window.URL.revokeObjectURL(url);
+    } catch {}
+  };
+
+  return (
+    <div className="p-6 text-white">
+      <h1 className="text-2xl font-bold mb-4">Admin Dashboard</h1>
+      <div className="mb-4 space-x-2">
+        <label>
+          Last
+          <input
+            type="number"
+            value={days}
+            onChange={e => setDays(e.target.value)}
+            className="mx-2 w-16 p-1 rounded text-black"
+          />
+          days
+        </label>
+        <button
+          onClick={fetchSessions}
+          className="bg-blue-500 text-white px-2 py-1 rounded"
+        >
+          Refresh
+        </button>
+      </div>
+      <div className="overflow-auto">
+        <table className="min-w-full text-sm">
+          <thead>
+            <tr className="text-left">
+              <th className="p-2">Date</th>
+              <th className="p-2">Name</th>
+              <th className="p-2">Email</th>
+              <th className="p-2">Agents</th>
+              <th className="p-2">Status</th>
+              <th className="p-2">Download</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sessions.map(s => (
+              <tr key={s.sessionId} className="border-t border-white/20">
+                <td className="p-2">{new Date(s.date).toLocaleString()}</td>
+                <td className="p-2">{s.name || '-'}</td>
+                <td className="p-2">{s.email || '-'}</td>
+                <td className="p-2">{(s.agents || []).join(', ')}</td>
+                <td className="p-2">{s.status}</td>
+                <td className="p-2">
+                  <button
+                    onClick={() => downloadSession(s.sessionId)}
+                    className="text-blue-400 underline"
+                  >
+                    JSON
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/frontend/admin/index.html
+++ b/frontend/admin/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Admin Dashboard</title>
+  <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
+  <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2/dist/tailwind.min.css" rel="stylesheet">
+</head>
+<body class="bg-gray-900">
+  <div id="root"></div>
+  <script type="text/babel" src="dashboard.jsx"></script>
+  <script type="text/babel">
+    ReactDOM.render(<AdminDashboard />, document.getElementById('root'));
+  </script>
+</body>
+</html>

--- a/functions/index.js
+++ b/functions/index.js
@@ -9,6 +9,13 @@ const agentMetadata = require('../agents/agent-metadata.json');
 // Load environment variables from .env if present
 dotenv.config();
 
+const ADMIN_KEY = process.env.ADMIN_KEY || 'changeme';
+
+function isAuthorized(req) {
+  const key = req.headers['x-admin-key'] || req.query.key;
+  return key === ADMIN_KEY;
+}
+
 const app = express();
 app.use(cors());
 app.use(express.json());
@@ -118,6 +125,43 @@ app.use((req, res, next) => {
 
 // Object to hold loaded agents keyed by file name (without extension)
 const registeredAgents = loadAgents();
+
+app.use('/admin', (req, res, next) => {
+  if (!isAuthorized(req)) return res.status(401).send('Unauthorized');
+  next();
+});
+
+app.use('/admin', express.static(path.join(__dirname, '..', 'frontend', 'admin')));
+
+app.get('/logs/sessions', (req, res) => {
+  if (!isAuthorized(req)) return res.status(401).json({ error: 'Unauthorized' });
+  ensureSessionFiles();
+  const { days } = req.query;
+  const cutoff = days ? Date.now() - parseInt(days, 10) * 86400000 : null;
+  const files = fs.readdirSync(SESSION_LOG_DIR).filter(f => f.endsWith('.json'));
+  const sessions = files.map(file => {
+    const id = path.basename(file, '.json');
+    const entries = JSON.parse(fs.readFileSync(path.join(SESSION_LOG_DIR, file), 'utf8'));
+    if (!Array.isArray(entries) || entries.length === 0) return null;
+    const first = entries[0];
+    const last = entries[entries.length - 1];
+    const ts = first.timestamp || '';
+    if (cutoff && new Date(ts).getTime() < cutoff) return null;
+    const name = first.input?.clientName || first.input?.companyName || first.clientName || '';
+    const email = first.input?.email || '';
+    const agents = [...new Set(entries.map(e => e.agent).filter(Boolean))];
+    const status = last.status || 'unknown';
+    return { sessionId: id, name, email, date: ts, agents, status };
+  }).filter(Boolean).sort((a, b) => new Date(b.date) - new Date(a.date));
+  res.json(sessions);
+});
+
+app.get('/logs/sessions/:id', (req, res) => {
+  if (!isAuthorized(req)) return res.status(401).send('Unauthorized');
+  const file = path.join(SESSION_LOG_DIR, `${req.params.id}.json`);
+  if (!fs.existsSync(file)) return res.status(404).json({ error: 'Not found' });
+  res.download(file);
+});
 
 // Endpoint to execute a specific agent
 app.post('/run-agent', async (req, res) => {


### PR DESCRIPTION
## Summary
- add ADMIN_KEY env config and helper
- expose session log API and /admin static route
- create AdminDashboard React component
- serve simple admin dashboard page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68548ba75a048323ae07361d54a253ca