### PR TITLE
Add report sharing and zip export

### DIFF
--- a/frontend/client/ClientPortal.jsx
+++ b/frontend/client/ClientPortal.jsx
@@ -1,6 +1,33 @@
 import React from 'react';
+import JSZip from 'jszip';
+import { saveAs } from 'file-saver';
 
 export default function ClientPortal({ reports = [] }) {
+  const exportZip = async (url) => {
+    try {
+      const res = await fetch(url);
+      const blob = await res.blob();
+      const zip = new JSZip();
+      zip.file('report.pdf', blob);
+      const meta = { url, exported: new Date().toISOString() };
+      zip.file('metadata.json', JSON.stringify(meta, null, 2));
+      const content = await zip.generateAsync({ type: 'blob' });
+      saveAs(content, `report-${Date.now()}.zip`);
+    } catch {
+      alert('Failed to export');
+    }
+  };
+
+  const copyLink = (url) => {
+    const token = btoa(url);
+    const share = `${window.location.origin}/share/${encodeURIComponent(token)}`;
+    navigator.clipboard.writeText(share).then(() => {
+      alert('Link copied!');
+    }).catch(() => {
+      alert('Copy failed');
+    });
+  };
+
   return (
     <div className="p-6 text-white">
       <h1 className="text-2xl font-bold mb-4">Your Reports</h1>
@@ -9,10 +36,16 @@ export default function ClientPortal({ reports = [] }) {
       ) : (
         <ul className="list-disc pl-5 space-y-2">
           {reports.map((link, idx) => (
-            <li key={idx}>
+            <li key={idx} className="flex items-center gap-3">
               <a href={link} className="text-blue-400 underline" target="_blank" rel="noopener noreferrer">
                 {link.split('/').pop()}
               </a>
+              <button onClick={() => exportZip(link)} className="text-sm text-green-400 underline">
+                Export to ZIP
+              </button>
+              <button onClick={() => copyLink(link)} className="text-sm text-yellow-400 underline">
+                Copy Shareable Link
+              </button>
             </li>
           ))}
         </ul>

--- a/frontend/client/PublicViewer.jsx
+++ b/frontend/client/PublicViewer.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+export default function PublicViewer({ url = '' }) {
+  return (
+    <div className="p-6 text-white">
+      <h1 className="text-xl font-bold mb-4">Shared Report</h1>
+      {url ? (
+        <object data={url} type="application/pdf" className="w-full h-screen">
+          <p className="text-center">
+            PDF preview not available. <a href={url} className="underline" target="_blank" rel="noopener noreferrer">Download</a>
+          </p>
+        </object>
+      ) : (
+        <p>No report found.</p>
+      )}
+    </div>
+  );
+}

--- a/functions/index.js
+++ b/functions/index.js
@@ -462,6 +462,40 @@ app.get('/client/login', (req, res) => {
   </html>`);
 });
 
+// Decode share token and redirect to viewer
+app.get('/share/:token', (req, res) => {
+  try {
+    const decoded = Buffer.from(req.params.token, 'base64').toString('utf8');
+    return res.redirect(`/viewer?file=${encodeURIComponent(decoded)}`);
+  } catch {
+    return res.status(400).send('Invalid token');
+  }
+});
+
+// Public viewer page (read-only)
+app.get('/viewer', (req, res) => {
+  const file = req.query.file || '';
+  if (!file.startsWith('/reports/')) return res.status(400).send('Invalid file');
+
+  res.send(`<!DOCTYPE html>
+  <html>
+  <head>
+    <meta charset="UTF-8">
+    <title>Shared Report</title>
+    <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
+    <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
+    <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+    <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2/dist/tailwind.min.css" rel="stylesheet">
+  </head>
+  <body class="bg-gray-900">
+    <div id="root"></div>
+    <script>window.reportUrl = ${JSON.stringify(file)};</script>
+    <script type="text/babel" src="/client/PublicViewer.jsx"></script>
+    <script type="text/babel">ReactDOM.render(<PublicViewer url={window.reportUrl} />, document.getElementById('root'));</script>
+  </body>
+  </html>`);
+});
+
 // Endpoint to fetch current session status
 app.get('/status/:sessionId', (req, res) => {
   const { sessionId } = req.params;

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "express": "^5.1.0",
         "file-saver": "^2.0.5",
         "html2pdf.js": "^0.10.3",
+        "jszip": "^3.10.1",
         "nodemailer": "^6.9.1",
         "pdfkit": "^0.13.0",
         "reactflow": "^11.11.4"
@@ -680,6 +681,12 @@
         "url": "https://opencollective.com/core-js"
       }
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
     "node_modules/cors": {
       "version": "2.8.5",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
@@ -1345,6 +1352,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -1630,6 +1643,33 @@
         "html2canvas": "^1.0.0-rc.5"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jszip/node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
     "node_modules/linebreak": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
@@ -1868,6 +1908,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -1970,6 +2016,33 @@
         "react": ">=17",
         "react-dom": ">=17"
       }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readable-stream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
     },
     "node_modules/regenerator-runtime": {
       "version": "0.13.11",
@@ -2149,6 +2222,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
+    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -2259,6 +2338,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
     "node_modules/svg-pathdata": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
@@ -2350,6 +2444,12 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/utrie": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "express": "^5.1.0",
     "file-saver": "^2.0.5",
     "html2pdf.js": "^0.10.3",
+    "jszip": "^3.10.1",
     "nodemailer": "^6.9.1",
     "pdfkit": "^0.13.0",
     "reactflow": "^11.11.4"


### PR DESCRIPTION
## Summary
- add JSZip dependency
- update ClientPortal UI with Export to ZIP and Copy Shareable Link options
- implement public viewer React component
- add `/share/:token` and `/viewer` routes to display shared PDF reports

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685494b838b08323836db2ee11a3f2ad