### PR TITLE
Add audit feed to client portal

### DIFF
--- a/frontend/client/ClientPortal.jsx
+++ b/frontend/client/ClientPortal.jsx
@@ -1,8 +1,31 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import JSZip from 'jszip';
 import { saveAs } from 'file-saver';
 
 export default function ClientPortal({ reports = [] }) {
+  const [sidebarOpen, setSidebarOpen] = useState(true);
+  const [activeTab, setActiveTab] = useState('Reports');
+  const [feed, setFeed] = useState([]);
+
+  useEffect(() => {
+    const fetchLogs = async () => {
+      try {
+        const res = await fetch('/audit?limit=20');
+        const data = await res.json();
+        setFeed(data);
+      } catch (err) {
+        console.error('Failed to load audit logs', err);
+      }
+    };
+    fetchLogs();
+    const id = setInterval(fetchLogs, 10000);
+    return () => clearInterval(id);
+  }, []);
+
+  const addLocalEvent = (desc) => {
+    setFeed((f) => [{ timestamp: new Date().toISOString(), description: desc }, ...f]);
+  };
+
   const exportZip = async (url) => {
     try {
       const res = await fetch(url);
@@ -13,6 +36,7 @@ export default function ClientPortal({ reports = [] }) {
       zip.file('metadata.json', JSON.stringify(meta, null, 2));
       const content = await zip.generateAsync({ type: 'blob' });
       saveAs(content, `report-${Date.now()}.zip`);
+      addLocalEvent(`Downloaded ${url.split('/').pop()}`);
     } catch {
       alert('Failed to export');
     }
@@ -21,35 +45,92 @@ export default function ClientPortal({ reports = [] }) {
   const copyLink = (url) => {
     const token = btoa(url);
     const share = `${window.location.origin}/share/${encodeURIComponent(token)}`;
-    navigator.clipboard.writeText(share).then(() => {
-      alert('Link copied!');
-    }).catch(() => {
-      alert('Copy failed');
-    });
+    navigator.clipboard
+      .writeText(share)
+      .then(() => {
+        addLocalEvent(`Created share link for ${url.split('/').pop()}`);
+        alert('Link copied!');
+      })
+      .catch(() => {
+        alert('Copy failed');
+      });
   };
 
   return (
-    <div className="p-6 text-white">
-      <h1 className="text-2xl font-bold mb-4">Your Reports</h1>
-      {reports.length === 0 ? (
-        <p>No reports available.</p>
-      ) : (
-        <ul className="list-disc pl-5 space-y-2">
-          {reports.map((link, idx) => (
-            <li key={idx} className="flex items-center gap-3">
-              <a href={link} className="text-blue-400 underline" target="_blank" rel="noopener noreferrer">
-                {link.split('/').pop()}
-              </a>
-              <button onClick={() => exportZip(link)} className="text-sm text-green-400 underline">
-                Export to ZIP
-              </button>
-              <button onClick={() => copyLink(link)} className="text-sm text-yellow-400 underline">
-                Copy Shareable Link
-              </button>
-            </li>
-          ))}
-        </ul>
-      )}
+    <div className="flex text-white">
+      <div className={`bg-gray-800 transition-all duration-300 ${sidebarOpen ? 'w-48' : 'w-12'} overflow-hidden`}>
+        <button className="p-2 focus:outline-none" onClick={() => setSidebarOpen(!sidebarOpen)}>
+          {sidebarOpen ? '❮' : '❯'}
+        </button>
+        {sidebarOpen && (
+          <ul className="mt-4 space-y-2">
+            {['Reports', 'Activity', 'Billing'].map((tab) => (
+              <li key={tab}>
+                <button
+                  onClick={() => setActiveTab(tab)}
+                  className={`w-full text-left px-3 py-1 rounded hover:bg-gray-700 transition-colors ${
+                    activeTab === tab ? 'font-bold' : ''
+                  }`}
+                >
+                  {tab}
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+      <div className="flex-1 p-6">
+        {activeTab === 'Reports' && (
+          <div>
+            <h1 className="text-2xl font-bold mb-4">Your Reports</h1>
+            {reports.length === 0 ? (
+              <p>No reports available.</p>
+            ) : (
+              <ul className="list-disc pl-5 space-y-2">
+                {reports.map((link, idx) => (
+                  <li key={idx} className="flex items-center gap-3">
+                    <a href={link} className="text-blue-400 underline" target="_blank" rel="noopener noreferrer">
+                      {link.split('/').pop()}
+                    </a>
+                    <button onClick={() => exportZip(link)} className="text-sm text-green-400 underline">
+                      Export to ZIP
+                    </button>
+                    <button onClick={() => copyLink(link)} className="text-sm text-yellow-400 underline">
+                      Copy Shareable Link
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        )}
+
+        {activeTab === 'Activity' && (
+          <div>
+            <h1 className="text-2xl font-bold mb-4">Recent Activity</h1>
+            <ul className="space-y-2">
+              {feed.map((item, idx) => (
+                <li
+                  key={idx}
+                  className="bg-gray-800 p-3 rounded transition-all duration-300 hover:bg-gray-700"
+                >
+                  <p className="text-sm text-gray-400">
+                    {new Date(item.timestamp).toLocaleString()}
+                  </p>
+                  <p>{item.description || `${item.agent}: ${item.resultSummary || item.inputSummary}`}</p>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {activeTab === 'Billing' && (
+          <div>
+            <h1 className="text-2xl font-bold mb-4">Billing</h1>
+            <p>Billing information coming soon.</p>
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/functions/auditLogger.js
+++ b/functions/auditLogger.js
@@ -65,4 +65,4 @@ function logAgentAction({ sessionId, agent, input, result }) {
   });
 }
 
-module.exports = { logAgentAction };
+module.exports = { logAgentAction, readAuditLogs };

--- a/functions/index.js
+++ b/functions/index.js
@@ -8,7 +8,7 @@ const PDFDocument = require('pdfkit');
 const crypto = require('crypto');
 const loadAgents = require('./loadAgents');
 const agentMetadata = require('../agents/agent-metadata.json');
-const { logAgentAction } = require('./auditLogger');
+const { logAgentAction, readAuditLogs } = require('./auditLogger');
 
 // Load environment variables from .env if present
 dotenv.config();
@@ -494,6 +494,17 @@ app.get('/viewer', (req, res) => {
     <script type="text/babel">ReactDOM.render(<PublicViewer url={window.reportUrl} />, document.getElementById('root'));</script>
   </body>
   </html>`);
+});
+
+// Return recent audit logs
+app.get('/audit', (req, res) => {
+  try {
+    const limit = parseInt(req.query.limit || '50', 10);
+    const logs = readAuditLogs().slice(-limit).reverse();
+    res.json(logs);
+  } catch {
+    res.status(500).json({ error: 'Failed to read audit logs' });
+  }
 });
 
 // Endpoint to fetch current session status


### PR DESCRIPTION
## Summary
- expose audit logs via `/audit` endpoint
- export `readAuditLogs` helper
- enhance `ClientPortal.jsx` with sidebar filters and real-time activity feed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854965ce37483239352cb5bc36b6dda