### PR TITLE
Add agent dependency execution support

### DIFF
--- a/agents/agent-metadata.json
+++ b/agents/agent-metadata.json
@@ -12,6 +12,7 @@
       "confidenceScore": "number"
     },
     "category": "CX / Marketing",
+    "dependsOn": ["website-scanner-agent"],
     "enabled": true,
     "version": "1.0.0",
     "createdBy": "Csp-Ai",
@@ -29,6 +30,7 @@
       "result": "markdown"
     },
     "category": "Documentation",
+    "dependsOn": ["insights-agent"],
     "enabled": true,
     "version": "1.0.0",
     "createdBy": "Csp-Ai",

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -43,6 +43,7 @@ Every agent must have an entry in `agents/agent-metadata.json`. A typical entry 
   "description": "Explains what the agent does.",
   "inputs": { "someInput": "string" },
   "outputs": { "result": "string" },
+  "dependsOn": ["other-agent"],
   "category": "Utility",
   "enabled": true,
   "version": "1.0.0",
@@ -52,6 +53,7 @@ Every agent must have an entry in `agents/agent-metadata.json`. A typical entry 
 ```
 
 Fields like `inputs` and `outputs` describe the expected shape of the request and response. `enabled` controls whether the API will allow execution.
+`dependsOn` is an optional array listing other agents that must run before this one. The backend resolves these dependencies and executes agents in order.
 
 ## API Usage
 


### PR DESCRIPTION
## Summary
- add `dependsOn` metadata for agents
- implement dependency-aware `executeAgent` helper
- update `/run-agent` endpoint to process dependencies
- document new `dependsOn` field
- visualize dependencies in Agent Builder using React Flow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854965101ec8323aaddfbe2807d6a0b