### PR TITLE
Add strategy board agent and dashboard

### DIFF
--- a/agents/agent-metadata.json
+++ b/agents/agent-metadata.json
@@ -91,5 +91,21 @@
     "version": "1.0.0",
     "createdBy": "Csp-Ai",
     "lastUpdated": "2025-06-19"
+  },
+  "board-agent": {
+    "name": "Strategy Board Agent",
+    "description": "Aggregates mentor metrics and logs to provide governance recommendations.",
+    "inputs": {},
+    "outputs": {
+      "agents": "array",
+      "growth": "array",
+      "recommendations": "array",
+      "mentorSummary": "string"
+    },
+    "category": "Governance",
+    "enabled": true,
+    "version": "1.0.0",
+    "createdBy": "Csp-Ai",
+    "lastUpdated": "2025-06-19"
   }
 }

--- a/agents/board-agent.js
+++ b/agents/board-agent.js
@@ -1,0 +1,67 @@
+const fs = require('fs');
+const path = require('path');
+const mentor = require('./mentor-agent');
+
+const LOG_DIR = path.join(__dirname, '..', 'logs');
+const BENCH_FILE = path.join(LOG_DIR, 'agent-benchmarks.json');
+const AUDIT_FILE = path.join(LOG_DIR, 'audit.json');
+const DEV_FILE = path.join(LOG_DIR, 'development-plans.json');
+const METADATA_FILE = path.join(__dirname, 'agent-metadata.json');
+
+function readJson(file, fallback) {
+  try {
+    if (!fs.existsSync(file)) return fallback;
+    const data = fs.readFileSync(file, 'utf8');
+    return JSON.parse(data);
+  } catch {
+    return fallback;
+  }
+}
+
+module.exports = {
+  run: async () => {
+    try {
+      const metadata = readJson(METADATA_FILE, {});
+      const benchmarks = readJson(BENCH_FILE, []);
+      const audit = readJson(AUDIT_FILE, []);
+      const devPlans = readJson(DEV_FILE, []);
+      const mentorOutput = await mentor.run();
+
+      const agents = Object.entries(metadata)
+        .filter(([, meta]) => meta.enabled)
+        .map(([id, meta]) => {
+          const bench = benchmarks.find(b => b.agent === id);
+          const lastUsed = bench ? bench.lastUsed : null;
+          const phase = lastUsed
+            ? (Date.now() - new Date(lastUsed).getTime() > 30 * 86400000
+                ? 'mature'
+                : 'growth')
+            : 'incubating';
+          return { id, name: meta.name, phase };
+        });
+
+      const now = Date.now();
+      const growth = Array.from({ length: 7 }, (_, i) => {
+        const day = new Date(now - (6 - i) * 86400000);
+        const dStr = day.toISOString().split('T')[0];
+        const count = (Array.isArray(audit) ? audit : [])
+          .filter(e => e.timestamp && e.timestamp.startsWith(dStr)).length;
+        return { date: dStr, count };
+      });
+
+      const recommendations = [
+        ...(mentorOutput.plans || []),
+        ...devPlans.flatMap(p => p.plans || [])
+      ];
+
+      return {
+        agents,
+        growth,
+        recommendations,
+        mentorSummary: mentorOutput.summary || ''
+      };
+    } catch (err) {
+      return { error: `Board agent failed: ${err.message}` };
+    }
+  }
+};

--- a/frontend/board/StrategyBoard.jsx
+++ b/frontend/board/StrategyBoard.jsx
@@ -1,0 +1,64 @@
+import React from 'react';
+
+export default function StrategyBoard({ data }) {
+  const agents = data.agents || [];
+  const growth = data.growth || [];
+  const recs = data.recommendations || [];
+  return (
+    <div className="p-6 text-white">
+      <h1 className="text-2xl font-bold mb-4">Strategy Board</h1>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
+        <div className="bg-white/10 p-4 rounded">
+          <h2 className="text-sm">Active Agents</h2>
+          <p className="text-xl font-semibold">{agents.length}</p>
+        </div>
+        <div className="bg-white/10 p-4 rounded">
+          <h2 className="text-sm mb-2">Board Recommendations</h2>
+          <ul className="list-disc pl-4 text-sm space-y-1">
+            {recs.map((r, i) => (
+              <li key={i}>{r.suggestion || r}</li>
+            ))}
+          </ul>
+        </div>
+      </div>
+      <div className="mb-6">
+        <h2 className="text-lg font-semibold mb-2">Lifecycle Phase</h2>
+        <table className="min-w-full text-sm">
+          <thead>
+            <tr className="text-left">
+              <th className="p-2">Agent</th>
+              <th className="p-2">Phase</th>
+            </tr>
+          </thead>
+          <tbody>
+            {agents.map(a => (
+              <tr key={a.id} className="border-t border-white/20">
+                <td className="p-2">{a.name}</td>
+                <td className="p-2">{a.phase}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <div>
+        <h2 className="text-lg font-semibold mb-2">Growth Trends (Last 7 Days)</h2>
+        <table className="min-w-full text-sm">
+          <thead>
+            <tr className="text-left">
+              <th className="p-2">Date</th>
+              <th className="p-2">Runs</th>
+            </tr>
+          </thead>
+          <tbody>
+            {growth.map(g => (
+              <tr key={g.date} className="border-t border-white/20">
+                <td className="p-2">{g.date.slice(5)}</td>
+                <td className="p-2">{g.count}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/functions/index.js
+++ b/functions/index.js
@@ -302,6 +302,8 @@ app.use('/admin', express.static(path.join(__dirname, '..', 'frontend', 'admin')
 
 // Serve client portal assets
 app.use('/client', express.static(path.join(__dirname, '..', 'frontend', 'client')));
+// Serve strategy board assets
+app.use('/board', express.static(path.join(__dirname, '..', 'frontend', 'board')));
 
 // Serve generated PDF reports from logs/reports
 app.use('/reports', express.static('logs/reports'));
@@ -560,6 +562,33 @@ app.get('/viewer', (req, res) => {
     <script type="text/babel">ReactDOM.render(<PublicViewer url={window.reportUrl} />, document.getElementById('root'));</script>
   </body>
   </html>`);
+});
+
+// Strategy board dashboard
+app.get('/strategy-board', async (req, res) => {
+  try {
+    const boardAgent = require('../agents/board-agent');
+    const data = await boardAgent.run();
+    res.send(`<!DOCTYPE html>
+    <html>
+    <head>
+      <meta charset="UTF-8">
+      <title>Strategy Board</title>
+      <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
+      <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
+      <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+      <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2/dist/tailwind.min.css" rel="stylesheet">
+    </head>
+    <body class="bg-gray-900">
+      <div id="root"></div>
+      <script>window.boardData = ${JSON.stringify(data)};</script>
+      <script type="text/babel" src="/board/StrategyBoard.jsx"></script>
+      <script type="text/babel">ReactDOM.render(<StrategyBoard data={window.boardData} />, document.getElementById('root'));</script>
+    </body>
+    </html>`);
+  } catch (err) {
+    res.status(500).send('Failed to render board');
+  }
 });
 
 // Return recent audit logs


### PR DESCRIPTION
## Summary
- add board-agent for lifecycle governance
- create StrategyBoard React component
- expose `/strategy-board` endpoint that renders dashboard
- register new agent in metadata

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68549bdfa3a88323b423f1b2dc2ee397