### PR TITLE
Fix /reports route duplication

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -51,9 +51,6 @@ function validateToken(token) {
   return data.email;
 }
 
-const PUBLIC_REPORTS_DIR = path.join(__dirname, '..', 'reports');
-app.use('/reports', express.static(PUBLIC_REPORTS_DIR));
-
 const LOG_DIR = path.join(__dirname, '..', 'logs');
 const LOG_FILE = path.join(LOG_DIR, 'logs.json');
 const SESSION_STATUS_FILE = path.join(LOG_DIR, 'sessionStatus.json');


### PR DESCRIPTION
## Summary
- remove redundant PUBLIC_REPORTS_DIR and duplicate `/reports` route
- confirm agent submission endpoint logs new entries

## Testing
- `npm test`
- `npm start` *(terminated after launch)*
- `curl -s -F metadata='...' -F code=@sample-agent.zip -H "x-admin-key: changeme" http://localhost:3000/submit-agent`

------
https://chatgpt.com/codex/tasks/task_e_68549c8eecd083238e3fc78219f96db7