### PR TITLE
Integrate localization and board agent features

### DIFF
--- a/agents/agent-metadata.json
+++ b/agents/agent-metadata.json
@@ -18,7 +18,9 @@
     "enabled": true,
     "version": "1.0.0",
     "createdBy": "Csp-Ai",
-    "lastUpdated": "2025-06-19"
+    "lastUpdated": "2025-06-19",
+    "locales": ["en"],
+    "lifecycle": "production"
   },
   "report-generator-agent": {
     "name": "Report Generator",
@@ -38,7 +40,9 @@
     "enabled": true,
     "version": "1.0.0",
     "createdBy": "Csp-Ai",
-    "lastUpdated": "2025-06-19"
+    "lastUpdated": "2025-06-19",
+    "locales": ["en"],
+    "lifecycle": "production"
   },
   "website-scanner-agent": {
     "name": "Website Scanner Agent",
@@ -56,7 +60,9 @@
     "enabled": true,
     "version": "1.0.0",
     "createdBy": "Csp-Ai",
-    "lastUpdated": "2025-06-19"
+    "lastUpdated": "2025-06-19",
+    "locales": ["en"],
+    "lifecycle": "production"
   },
   "data-analyst-agent": {
     "name": "Data Analyst Agent",
@@ -75,7 +81,9 @@
     "enabled": true,
     "version": "1.0.0",
     "createdBy": "Csp-Ai",
-    "lastUpdated": "2025-06-19"
+    "lastUpdated": "2025-06-19",
+    "locales": ["en"],
+    "lifecycle": "production"
   },
   "mentor-agent": {
     "name": "Mentor Agent",
@@ -90,7 +98,9 @@
     "enabled": true,
     "version": "1.0.0",
     "createdBy": "Csp-Ai",
-    "lastUpdated": "2025-06-19"
+    "lastUpdated": "2025-06-19",
+    "locales": ["en"],
+    "lifecycle": "production"
   },
   "board-agent": {
     "name": "Strategy Board Agent",
@@ -106,6 +116,8 @@
     "enabled": true,
     "version": "1.0.0",
     "createdBy": "Csp-Ai",
-    "lastUpdated": "2025-06-19"
+    "lastUpdated": "2025-06-19",
+    "locales": ["en"],
+    "lifecycle": "beta"
   }
 }


### PR DESCRIPTION
## Summary
- resolve leftover conflicts in agent-metadata.json
- add locales and lifecycle fields for all agents
- add localization utilities and endpoints
- keep strategy board route

## Testing
- `npm test`
- `npm start` (server started and agents loaded)

------
https://chatgpt.com/codex/tasks/task_e_68549da57dc08323b895c21d8b80e56a