### PR TITLE
Add locale metadata and LibreTranslate API

### DIFF
--- a/agents/agent-metadata.json
+++ b/agents/agent-metadata.json
@@ -18,7 +18,9 @@
     "enabled": true,
     "version": "1.0.0",
     "createdBy": "Csp-Ai",
-    "lastUpdated": "2025-06-19"
+    "lastUpdated": "2025-06-19",
+    "lifecycle": "production",
+    "locale": "en-US"
   },
   "report-generator-agent": {
     "name": "Report Generator",
@@ -38,7 +40,9 @@
     "enabled": true,
     "version": "1.0.0",
     "createdBy": "Csp-Ai",
-    "lastUpdated": "2025-06-19"
+    "lastUpdated": "2025-06-19",
+    "lifecycle": "production",
+    "locale": "en-US"
   },
   "website-scanner-agent": {
     "name": "Website Scanner Agent",
@@ -56,7 +60,9 @@
     "enabled": true,
     "version": "1.0.0",
     "createdBy": "Csp-Ai",
-    "lastUpdated": "2025-06-19"
+    "lastUpdated": "2025-06-19",
+    "lifecycle": "production",
+    "locale": "en-US"
   },
   "data-analyst-agent": {
     "name": "Data Analyst Agent",
@@ -75,7 +81,9 @@
     "enabled": true,
     "version": "1.0.0",
     "createdBy": "Csp-Ai",
-    "lastUpdated": "2025-06-19"
+    "lastUpdated": "2025-06-19",
+    "lifecycle": "production",
+    "locale": "en-US"
   },
   "mentor-agent": {
     "name": "Mentor Agent",
@@ -90,7 +98,9 @@
     "enabled": true,
     "version": "1.0.0",
     "createdBy": "Csp-Ai",
-    "lastUpdated": "2025-06-19"
+    "lastUpdated": "2025-06-19",
+    "lifecycle": "production",
+    "locale": "en-US"
   },
   "board-agent": {
     "name": "Strategy Board Agent",
@@ -106,6 +116,8 @@
     "enabled": true,
     "version": "1.0.0",
     "createdBy": "Csp-Ai",
-    "lastUpdated": "2025-06-19"
+    "lastUpdated": "2025-06-19",
+    "lifecycle": "production",
+    "locale": "en-US"
   }
 }


### PR DESCRIPTION
## Summary
- add `lifecycle` and `locale` metadata to all agents
- integrate LibreTranslate in `functions/index.js`
- expose `/translate`, `/detect-language`, and `/locales` routes

## Testing
- `npm test`
- `curl -I https://libretranslate.de/languages` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68549f019734832393faef2a0fab3a72