### PR TITLE
Add production health dashboard

### DIFF
--- a/agents/agent-metadata.json
+++ b/agents/agent-metadata.json
@@ -15,13 +15,14 @@
     "dependsOn": [
       "website-scanner-agent"
     ],
-    "enabled": true,
-    "version": "1.0.0",
-    "createdBy": "Csp-Ai",
-    "lastUpdated": "2025-06-19",
-    "locales": ["en", "es", "fr"],
-    "lifecycle": "production",
-    "locale": "en-US"
+      "enabled": true,
+      "version": "1.0.0",
+      "createdBy": "Csp-Ai",
+      "lastUpdated": "2025-06-19",
+      "critical": true,
+      "locales": ["en", "es", "fr"],
+      "lifecycle": "production",
+      "locale": "en-US"
   },
   "report-generator-agent": {
     "name": "Report Generator",
@@ -42,6 +43,7 @@
     "version": "1.0.0",
     "createdBy": "Csp-Ai",
     "lastUpdated": "2025-06-19",
+    "critical": true,
     "locales": ["en", "es", "fr"],
     "lifecycle": "production",
     "locale": "en-US"
@@ -63,6 +65,7 @@
     "version": "1.0.0",
     "createdBy": "Csp-Ai",
     "lastUpdated": "2025-06-19",
+    "critical": true,
     "locales": ["en", "es", "fr"],
     "lifecycle": "production",
     "locale": "en-US"
@@ -85,6 +88,7 @@
     "version": "1.0.0",
     "createdBy": "Csp-Ai",
     "lastUpdated": "2025-06-19",
+    "critical": true,
     "locales": ["en", "es", "fr"],
     "lifecycle": "production",
     "locale": "en-US"
@@ -103,6 +107,7 @@
     "version": "1.0.0",
     "createdBy": "Csp-Ai",
     "lastUpdated": "2025-06-19",
+    "critical": true,
     "locales": ["en", "es", "fr"],
     "lifecycle": "production",
     "locale": "en-US"
@@ -122,6 +127,7 @@
     "version": "1.0.0",
     "createdBy": "Csp-Ai",
     "lastUpdated": "2025-06-19",
+    "critical": true,
     "locales": ["en", "es", "fr"],
     "lifecycle": "production",
     "locale": "en-US"

--- a/frontend/HealthDashboard.jsx
+++ b/frontend/HealthDashboard.jsx
@@ -1,0 +1,56 @@
+import React, { useEffect, useState } from 'react';
+
+export default function HealthDashboard() {
+  const [status, setStatus] = useState(null);
+
+  useEffect(() => {
+    const fetchStatus = async () => {
+      try {
+        const res = await fetch('/health-check');
+        const json = await res.json();
+        setStatus(json);
+      } catch {
+        setStatus(null);
+      }
+    };
+    fetchStatus();
+  }, []);
+
+  if (!status) {
+    return <div className="p-6 text-white">Loading...</div>;
+  }
+
+  return (
+    <div className="p-6 text-white">
+      <h1 className="text-2xl font-bold mb-4">System Health</h1>
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
+        <div className={`p-4 rounded ${status.translation ? 'bg-green-600/50' : 'bg-red-600/50'}`}> 
+          <h2 className="text-sm">Translation API</h2>
+          <p className="text-lg font-semibold">{status.translation ? 'Online' : 'Down'}</p>
+        </div>
+        <div className={`p-4 rounded ${status.auditLogRecent ? 'bg-green-600/50' : 'bg-red-600/50'}`}> 
+          <h2 className="text-sm">Audit Logs</h2>
+          <p className="text-lg font-semibold">{status.auditLogRecent ? 'Updating' : 'Stale'}</p>
+        </div>
+      </div>
+      <table className="min-w-full text-sm">
+        <thead>
+          <tr className="text-left">
+            <th className="p-2">Agent</th>
+            <th className="p-2">Latency (ms)</th>
+            <th className="p-2">Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          {status.agents.map(a => (
+            <tr key={a.agent} className="border-t border-white/20">
+              <td className="p-2">{a.agent}</td>
+              <td className="p-2">{a.latencyMs}</td>
+              <td className="p-2">{a.success ? '✅' : `❌ ${a.error || ''}`}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/functions/healthCheck.js
+++ b/functions/healthCheck.js
@@ -1,0 +1,94 @@
+const fs = require('fs');
+const path = require('path');
+const { performance } = require('perf_hooks');
+const loadAgents = require('./loadAgents');
+const agentMetadata = require('../agents/agent-metadata.json');
+const { readAuditLogs } = require('./auditLogger');
+
+const LT_URL = process.env.TRANSLATE_URL || 'https://libretranslate.de';
+
+function createMockInput(inputs = {}) {
+  const mock = {};
+  for (const [key, type] of Object.entries(inputs)) {
+    switch (type) {
+      case 'string':
+        mock[key] = 'test';
+        break;
+      case 'email':
+        mock[key] = 'test@example.com';
+        break;
+      case 'url':
+        mock[key] = 'https://example.com';
+        break;
+      case 'number':
+        mock[key] = 0;
+        break;
+      case 'array':
+        mock[key] = [];
+        break;
+      case 'object':
+        mock[key] = {};
+        break;
+      default:
+        mock[key] = null;
+    }
+  }
+  return mock;
+}
+
+async function checkAgent(agentName, meta, agents) {
+  const mockInput = createMockInput(meta.inputs);
+  const agent = agents[agentName];
+  const start = performance.now();
+  let success = false;
+  let error;
+  try {
+    if (!agent || typeof agent.run !== 'function') {
+      throw new Error('Agent module not found');
+    }
+    await Promise.resolve(agent.run(mockInput));
+    success = true;
+  } catch (err) {
+    error = err.message;
+  }
+  const latencyMs = Math.round(performance.now() - start);
+  return { agent: agentName, success, latencyMs, error };
+}
+
+async function checkTranslation() {
+  try {
+    const resp = await fetch(`${LT_URL}/languages`);
+    return resp.ok;
+  } catch {
+    return false;
+  }
+}
+
+function checkAuditLogs() {
+  try {
+    const logs = readAuditLogs();
+    if (!Array.isArray(logs) || !logs.length) return false;
+    const last = logs[logs.length - 1];
+    if (!last.timestamp) return false;
+    const ts = new Date(last.timestamp).getTime();
+    return Date.now() - ts < 24 * 60 * 60 * 1000;
+  } catch {
+    return false;
+  }
+}
+
+async function runHealthChecks() {
+  const agents = loadAgents();
+  const agentResults = [];
+  for (const [key, meta] of Object.entries(agentMetadata)) {
+    if (meta.enabled && meta.lifecycle === 'production' && meta.critical) {
+      agentResults.push(await checkAgent(key, meta, agents));
+    }
+  }
+  const translation = await checkTranslation();
+  const auditLogRecent = checkAuditLogs();
+  const overall = agentResults.every(r => r.success) && translation && auditLogRecent;
+  return { overall, agents: agentResults, translation, auditLogRecent };
+}
+
+module.exports = runHealthChecks;

--- a/functions/index.js
+++ b/functions/index.js
@@ -15,6 +15,7 @@ const {
   readAuditLogs,
   appendAuditLog,
 } = require('./auditLogger');
+const runHealthChecks = require('./healthCheck');
 
 // Load environment variables from .env if present
 dotenv.config();
@@ -706,6 +707,16 @@ app.post('/translate', async (req, res) => {
     res.json(data);
   } catch (err) {
     res.status(500).json({ error: 'Translation failed' });
+  }
+});
+
+// Health check summary
+app.get('/health-check', async (req, res) => {
+  try {
+    const summary = await runHealthChecks();
+    res.json(summary);
+  } catch (err) {
+    res.status(500).json({ error: 'Health check failed' });
   }
 });
 


### PR DESCRIPTION
## Summary
- tag each production agent as `critical`
- add backend health check to ping critical agents, audit logs, and translation API
- expose `/health-check` endpoint
- implement `HealthDashboard` frontend component

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854a93b19588323ae79c874d989a0b6