### PR TITLE
Update constitution with guardian agent

### DIFF
--- a/docs/AGENT_CONSTITUTION.md
+++ b/docs/AGENT_CONSTITUTION.md
@@ -1,152 +1,134 @@
 🧠 AGENT CONSTITUTION
 
-HybridDancers AI System
+Ai Agent Systems
 
-Last updated: 2025-06-19
+Last updated: 2025-06-20
 
 🔍 Purpose
 
-The Agent Constitution defines the core values, lifecycle, governance, and operational principles that all AI agents in the HybridDancers platform must adhere to. It is a shared agreement for autonomous agents to:
+The Agent Constitution defines the core values, lifecycle, governance, and operational principles that all AI agents in the Ai Agent Systems platform must adhere to. It is a shared agreement for autonomous agents to:
 
-Continuously grow through feedback
+- Continuously grow through feedback
+- Collaborate across modular pipelines
+- Remain explainable, ethical, and observable
 
-Collaborate across modular pipelines
+📊 Current Agent Ecosystem
 
-Remain explainable, ethical, and observable
+🔄 Pipeline Overview
 
-📐 Foundational Pillars
+| Stage | Agent(s) | Notes |
+|-------|----------|-------|
+| Data Capture | website-scanner-agent.js | Strong success rate (0.95) |
+| Analysis | insights-agent.js, data-analyst-agent.js | Insights missing implementation; analyst in incubation |
+| Governance | mentor-agent.js, board-agent.js, guardian-agent.js | Early stage, enforce constitution |
+| Reporting | report-generator-agent.js | Mature, high reliability (0.97) |
 
-1. Modularity
+Feedback Loops:
+- Mentor ⇄ Board: Mentor recommends, board aggregates
+- Guardian ⇄ All: Guardian audits behavior patterns, supports struggling agents, and nurtures maturity progression
+- Agents ➔ Report Generator: Central consumer of insights, drives client-facing output
 
-All agents must be single-purpose.
+Gaps:
+- logs/audit.json missing
+- insights-agent.js file absent
+- Some agents reside outside /agents/, triggering false compliance errors
 
-Communication occurs only through well-defined inputs/outputs.
+💡 Foundational Pillars
 
-No direct state sharing. All state must be passed explicitly or logged.
-
-2. Observability
-
-Every agent action must log:
-
-Timestamp
-
-Inputs
-
-Outputs
-
-Status (active, completed, failed)
-
-All logs are stored in logs/sessionStatus.json and logs/logs.json.
-
-3. Ethical Design
-
-No agents may access child_process, fs.unlink, or perform destructive actions without audit.
-
-All user data must be anonymized and stored securely.
-
-4. Lifecycle Classification
-
-Each agent must declare:
-
-{
-  "lifecycle": "{alpha|beta|production|deprecated}"
-}
-
-Lifecycle state is used by the board-agent to:
-
-Filter critical services
-
-Alert on broken dependencies
-
-Trigger promotion/demotion workflows
-
-5. Localization Support
-
-All agents must optionally support a locale parameter.
-
-Summaries and outputs should be translatable using translateText() utilities.
+1. **Modularity**
+   - All agents must be single-purpose.
+   - Communication occurs only through well-defined inputs/outputs.
+   - No direct state sharing. All state must be passed explicitly or logged.
+2. **Observability**
+   - Every agent action must log:
+     - Timestamp
+     - Inputs
+     - Outputs
+     - Status (active, completed, failed)
+   - Logs go to `logs/sessionStatus.json` and `logs/logs.json`
+3. **Ethical Design**
+   - No agents may access `child_process`, `fs.unlink`, or perform destructive actions without audit.
+   - All user data must be anonymized and stored securely.
+4. **Lifecycle Classification**
+   ```
+   {
+     "lifecycle": "{incubation|alpha|beta|production|deprecated}"
+   }
+   ```
+   Used by `board-agent.js` to trigger promotion, demotion, or alerts
+5. **Localization Support**
+   - All agents must optionally support a locale param
+   - Outputs should be translatable via `translateText()`
 
 ⚙️ Agent Responsibilities
 
-Role
+| Agent | Role |
+|-------|------|
+| mentor-agent.js | Audits logs, proposes plans, logs to `development-plans.json` |
+| board-agent.js | Lifecycle governance, aggregates mentor reports, flags violations |
+| guardian-agent.js | Enforces inter-agent harmony, resolves agent conflicts, ensures alignment with growth goals and ethical standards |
+| data-analyst-agent.js | Summarizes stats, trends, outliers |
+| report-generator-agent.js | Generates Markdown reports |
+| client-agent.js | User interface access |
 
-Description
+All agents must:
+- Register in `agent-metadata.json`
+- Include inputs, outputs, category, version, createdBy
 
-mentor-agent.js
+⟳ CI/CD & Governance Engine
 
-Audits logs and performance data, writes plans to development-plans.json.
+✅ GitHub Workflows
+- Enforce `npm test`, changelog entry, agent metadata update
+- mentor-agent and board-agent validate adherence to this constitution
+- guardian-agent proposes moral reasoning or psychological alignment changes for agents acting against the Constitution
 
-board-agent.js
+🔎 Continuous Evaluation
+- Promote agents with >0.95 success over 30 days
+- Demote agents with <0.8 or inactivity
+- Raise GitHub issues for violations (via `board-agent.js`)
+- Run health-checks to validate code/metadata consistency
 
-Aggregates mentor and audit data, recommends lifecycle status.
+🛄 Third-Party Plugin Pathway
 
-data-analyst-agent.js
+**Plugin Interface**
+Each plugin must expose `run(input)` and provide:
+```
+{
+  "name": "",
+  "lifecycle": "beta",
+  "locales": ["en", "es", "fr"],
+  "dependencies": []
+}
+```
 
-Compiles trends, benchmarks, and outlier metrics.
+**Sandbox & Validation**
+- Uploaded via `/submit-agent`
+- Executed in isolated process or container
+- Must pass:
+  - No banned code patterns
+  - Dry run
+  - Metadata validation
 
-report-generator-agent.js
+**Governance Extensions**
+- mentor-agent monitors plugin logs
+- board-agent triggers lifecycle changes and alerts
+- Daily growth metrics logged in `board-agent.js`
 
-Generates readable markdown reports.
+🔍 IP and Scalability Strategy
 
-client-agent.js
+**Versioning & Licensing**
+- Convert `report-generator-agent` and `data-analyst-agent` into versioned packages
+- Modularize into licensed microservices
 
-Interface for users to interact with sessions and agents.
+**Open Ecosystem Framework**
+- Provide plugin architecture with constitution enforcement
+- Enable external contributors to submit agents that pass security and lifecycle criteria
 
-All new agents must:
-
-Register in agent-metadata.json
-
-Include inputs, outputs, category, version, createdBy
-
-🔁 CI/CD Integration
-
-✅ GitHub Workflow Requirements
-
-Each agent PR must:
-
-Pass npm test
-
-Include a changelog entry
-
-Update agent-metadata.json
-
-Avoid modifying others’ outputs unless explicitly approved
-
-🧪 Continuous Evaluation
-
-Mentor and Board agents trigger regular evaluations of agent usage, error frequency, and growth compliance:
-
-Stale or unused agents are marked deprecated
-
-Emerging agents with sustained utility are promoted to beta/production
-
-📤 Submission & Review
-
-New agents must:
-
-Be submitted via /submit-agent
-
-Include:
-
-name, description, version, inputs, outputs
-
-A .zip containing a single agent.js file
-
-Pass dry-run and security checks
-
-Be reviewed by mentor-agent for integration
-
-🔭 Vision
-
-This constitution is a living document. It is meant to:
-
-Encourage sustainable innovation
-
-Promote collaboration between autonomous tools
-
-Maintain clarity as the HybridDancers system scales
-
-All agents must treat this constitution as the supreme reference point for operation, contribution, and evaluation.
+💄 Living Document
+This constitution is the canonical reference for all:
+- Contributions
+- Evaluations
+- Execution policies
 
 File Reference: docs/AGENT_CONSTITUTION.md
 Maintainer: board-agent.js

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 2025-06-20
+- Added `guardian-agent.js` to governance role definitions and responsibilities.
+- Documented "incubation" lifecycle stage.
+- Updated feedback loops and CI/CD governance notes.
+- Bumped constitution date to reflect changes.


### PR DESCRIPTION
## Summary
- document `guardian-agent.js` responsibilities
- note incubation lifecycle stage
- update CI/CD rules for guardian guidance
- add guardian feedback loop and add to governance stage
- create CHANGELOG

## Testing
- `npm test`
- `node agents/mentor-agent.js`
- `node agents/board-agent.js`


------
https://chatgpt.com/codex/tasks/task_e_6854b69aabb8832391e8e092410fe5bf