### PR TITLE
Add governance dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,15 @@ npm start
 The backend includes optional translation utilities powered by **LibreTranslate**. Pass a `locale` when calling `/run-agent` to automatically translate an agent's output. The API also exposes `/translate`, `/detect-language`, and `/locales` helpers for ad-hoc requests.
 
 Developers can submit new agents through `/submit-agent` with metadata and a zip file. Submissions are staged for manual review before integration.
+
+## 🔎 Governance Dashboard
+
+The `/dashboard` directory contains a React application that connects to Firestore for real-time monitoring. To build the dashboard:
+
+```bash
+cd dashboard
+npm install
+npm run build
+```
+
+The compiled assets are output to `public/dashboard` and automatically served via Firebase Hosting.

--- a/dashboard/.env.example
+++ b/dashboard/.env.example
@@ -1,0 +1,3 @@
+VITE_FIREBASE_API_KEY=your-key
+VITE_FIREBASE_AUTH_DOMAIN=your-domain.firebaseapp.com
+VITE_FIREBASE_PROJECT_ID=your-project-id

--- a/dashboard/.gitignore
+++ b/dashboard/.gitignore
@@ -1,0 +1,24 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -1,0 +1,10 @@
+# Governance Dashboard
+
+This React app visualizes agent status, misalignment proposals and execution logs in real time.
+
+```
+cd dashboard
+npm install
+npm run dev  # local dev
+npm run build  # outputs to ../public/dashboard
+```

--- a/dashboard/eslint.config.js
+++ b/dashboard/eslint.config.js
@@ -1,0 +1,33 @@
+import js from '@eslint/js'
+import globals from 'globals'
+import reactHooks from 'eslint-plugin-react-hooks'
+import reactRefresh from 'eslint-plugin-react-refresh'
+
+export default [
+  { ignores: ['dist'] },
+  {
+    files: ['**/*.{js,jsx}'],
+    languageOptions: {
+      ecmaVersion: 2020,
+      globals: globals.browser,
+      parserOptions: {
+        ecmaVersion: 'latest',
+        ecmaFeatures: { jsx: true },
+        sourceType: 'module',
+      },
+    },
+    plugins: {
+      'react-hooks': reactHooks,
+      'react-refresh': reactRefresh,
+    },
+    rules: {
+      ...js.configs.recommended.rules,
+      ...reactHooks.configs.recommended.rules,
+      'no-unused-vars': ['error', { varsIgnorePattern: '^[A-Z_]' }],
+      'react-refresh/only-export-components': [
+        'warn',
+        { allowConstantExport: true },
+      ],
+    },
+  },
+]

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AI Agent Dashboard</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "dashboard",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "lint": "eslint .",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
+    "firebase": "^11.9.1",
+    "react-router-dom": "^6.22.3"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.25.0",
+    "@types/react": "^19.1.2",
+    "@types/react-dom": "^19.1.2",
+    "@vitejs/plugin-react": "^4.4.1",
+    "eslint": "^9.25.0",
+    "eslint-plugin-react-hooks": "^5.2.0",
+    "eslint-plugin-react-refresh": "^0.4.19",
+    "globals": "^16.0.0",
+    "tailwindcss": "^3.4.4",
+    "postcss": "^8.4.38",
+    "autoprefixer": "^10.4.17",
+    "vite": "^6.3.5"
+  }
+}

--- a/dashboard/postcss.config.cjs
+++ b/dashboard/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/dashboard/src/App.jsx
+++ b/dashboard/src/App.jsx
@@ -1,0 +1,41 @@
+import { useState, useEffect } from 'react';
+import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom';
+import AgentStatusTable from './components/AgentStatusTable';
+import MisalignmentProposalsPanel from './components/MisalignmentProposalsPanel';
+import ExecutionLogViewer from './components/ExecutionLogViewer';
+import './index.css';
+
+export default function App() {
+  const [dark, setDark] = useState(
+    localStorage.getItem('theme') === 'dark'
+  );
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', dark);
+    localStorage.setItem('theme', dark ? 'dark' : 'light');
+  }, [dark]);
+
+  return (
+    <Router basename="/dashboard">
+      <div className="min-h-screen flex bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
+        <aside className="w-48 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 p-4 flex flex-col">
+          <nav className="flex flex-col space-y-2 flex-1">
+            <Link to="/" className="hover:underline">Status</Link>
+            <Link to="/proposals" className="hover:underline">Proposals</Link>
+            <Link to="/logs" className="hover:underline">Logs</Link>
+          </nav>
+          <button onClick={() => setDark(!dark)} className="text-sm mt-4">
+            Toggle {dark ? 'Light' : 'Dark'}
+          </button>
+        </aside>
+        <main className="flex-1 overflow-auto">
+          <Routes>
+            <Route path="/" element={<AgentStatusTable />} />
+            <Route path="/proposals" element={<MisalignmentProposalsPanel />} />
+            <Route path="/logs" element={<ExecutionLogViewer />} />
+          </Routes>
+        </main>
+      </div>
+    </Router>
+  );
+}

--- a/dashboard/src/components/AgentStatusTable.jsx
+++ b/dashboard/src/components/AgentStatusTable.jsx
@@ -1,0 +1,52 @@
+import { useEffect, useState } from 'react';
+import { collection, onSnapshot } from 'firebase/firestore';
+import { db } from '../firebase';
+
+const statusColors = {
+  development: 'bg-blue-100 text-blue-800',
+  testing: 'bg-yellow-100 text-yellow-800',
+  production: 'bg-green-100 text-green-800',
+  retired: 'bg-gray-200 text-gray-800',
+};
+
+export default function AgentStatusTable() {
+  const [agents, setAgents] = useState([]);
+
+  useEffect(() => {
+    const unsub = onSnapshot(collection(db, 'agent-metadata'), snap => {
+      const data = snap.docs.map(d => ({ id: d.id, ...d.data() }));
+      setAgents(data);
+    });
+    return unsub;
+  }, []);
+
+  return (
+    <div className="p-4 overflow-auto">
+      <h2 className="text-xl font-semibold mb-4">Agent Status</h2>
+      <table className="min-w-full text-sm">
+        <thead>
+          <tr className="text-left">
+            <th className="p-2">Name</th>
+            <th className="p-2">Lifecycle</th>
+            <th className="p-2">Alignment</th>
+            <th className="p-2">Misaligned</th>
+          </tr>
+        </thead>
+        <tbody>
+          {agents.map(a => (
+            <tr key={a.id} className="border-t border-gray-200 dark:border-gray-700">
+              <td className="p-2">{a.name || a.id}</td>
+              <td className="p-2">
+                <span className={`px-2 py-1 rounded text-xs font-medium ${statusColors[a.lifecycle] || 'bg-gray-100 text-gray-800'}`}>
+                  {a.lifecycle || 'unknown'}
+                </span>
+              </td>
+              <td className="p-2">{a.alignmentScore ?? '-'}</td>
+              <td className="p-2">{a.misaligned ? 'Yes' : 'No'}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/dashboard/src/components/ExecutionLogViewer.jsx
+++ b/dashboard/src/components/ExecutionLogViewer.jsx
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'react';
+import { collection, onSnapshot, query, orderBy } from 'firebase/firestore';
+import { db } from '../firebase';
+
+export default function ExecutionLogViewer() {
+  const [logs, setLogs] = useState([]);
+  const [filter, setFilter] = useState('');
+
+  useEffect(() => {
+    const q = query(collection(db, 'logs'), orderBy('timestamp', 'desc'));
+    const unsub = onSnapshot(q, snap => {
+      const data = snap.docs.map(d => ({ id: d.id, ...d.data() }));
+      setLogs(data);
+    });
+    return unsub;
+  }, []);
+
+  const filtered = filter
+    ? logs.filter(l => (l.agent || '').includes(filter))
+    : logs;
+
+  return (
+    <div className="p-4">
+      <h2 className="text-xl font-semibold mb-4">Execution Logs</h2>
+      <div className="mb-2">
+        <input
+          type="text"
+          placeholder="Filter by agent"
+          value={filter}
+          onChange={e => setFilter(e.target.value)}
+          className="border px-2 py-1 rounded w-48 dark:bg-gray-800"
+        />
+      </div>
+      <ul className="space-y-2 max-h-[70vh] overflow-auto">
+        {filtered.map(log => (
+          <li key={log.id} className="border rounded p-3 dark:border-gray-700">
+            <div className="text-sm text-gray-500">
+              {new Date(log.timestamp).toLocaleString()} - {log.agent}
+            </div>
+            <div className="text-sm mt-1 whitespace-pre-wrap">
+              {log.outputSnippet || log.output || ''}
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/dashboard/src/components/MisalignmentProposalsPanel.jsx
+++ b/dashboard/src/components/MisalignmentProposalsPanel.jsx
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react';
+import { doc, onSnapshot } from 'firebase/firestore';
+import { db } from '../firebase';
+
+export default function MisalignmentProposalsPanel() {
+  const [proposals, setProposals] = useState([]);
+
+  useEffect(() => {
+    const unsub = onSnapshot(doc(db, 'guardian', 'proposals'), snap => {
+      const data = snap.data() || {};
+      const list = data.proposals || data.list || [];
+      setProposals(Array.isArray(list) ? list : Object.values(list));
+    });
+    return unsub;
+  }, []);
+
+  return (
+    <div className="p-4">
+      <h2 className="text-xl font-semibold mb-4">Misalignment Proposals</h2>
+      <ul className="space-y-2">
+        {proposals.map((p, idx) => (
+          <li key={idx} className="bg-white/50 dark:bg-white/10 p-3 rounded">
+            <div className="font-semibold">{p.agent || p.name}</div>
+            <div className="text-sm text-gray-700 dark:text-gray-300">{p.action || p.suggestion}</div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/dashboard/src/firebase.js
+++ b/dashboard/src/firebase.js
@@ -1,0 +1,11 @@
+import { initializeApp } from 'firebase/app';
+import { getFirestore } from 'firebase/firestore';
+
+const firebaseConfig = {
+  apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
+  authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN,
+  projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID,
+};
+
+const app = initializeApp(firebaseConfig);
+export const db = getFirestore(app);

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/dashboard/src/main.jsx
+++ b/dashboard/src/main.jsx
@@ -1,0 +1,10 @@
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import './index.css'
+import App from './App.jsx'
+
+createRoot(document.getElementById('root')).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+)

--- a/dashboard/tailwind.config.cjs
+++ b/dashboard/tailwind.config.cjs
@@ -1,0 +1,10 @@
+module.exports = {
+  content: [
+    './index.html',
+    './src/**/*.{js,jsx,ts,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/dashboard/vite.config.js
+++ b/dashboard/vite.config.js
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+// https://vite.dev/config/
+export default defineConfig({
+  base: '/dashboard/',
+  plugins: [react()],
+  build: {
+    outDir: '../public/dashboard',
+    emptyOutDir: false,
+  },
+})

--- a/firebase.json
+++ b/firebase.json
@@ -6,6 +6,7 @@
     "public": "public",
     "cleanUrls": true,
     "rewrites": [
+      { "source": "/dashboard/**", "destination": "/dashboard/index.html" },
       { "source": "**", "function": "app" }
     ]
   },


### PR DESCRIPTION
## Summary
- scaffold React dashboard using Vite and Tailwind
- show agent status, guardian proposals and execution logs via Firestore
- add Firebase hosting rewrite for the dashboard
- document dashboard build steps

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854c0aea55c832397e6c03e58118b4e