### PR TITLE
Add dashboard deploy script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "monitor": "node scripts/agentHealthMonitor.js",
     "guardian": "node scripts/runGuardian.js",
     "lint": "eslint .",
-    "resolve-package-conflicts": "node scripts/packageConflictResolver.js"
+    "resolve-package-conflicts": "node scripts/packageConflictResolver.js",
+    "deploy:dashboard": "node scripts/deploy-dashboard.js"
   },
   "keywords": [
     "AI",

--- a/scripts/deploy-dashboard.js
+++ b/scripts/deploy-dashboard.js
@@ -1,0 +1,40 @@
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const rootDir = path.resolve(__dirname, '..');
+const distDir = path.join(rootDir, 'dashboard', 'dist');
+const buildDir = path.join(rootDir, 'dashboard', 'build');
+let sourceDir = null;
+
+if (fs.existsSync(distDir)) {
+  sourceDir = distDir;
+} else if (fs.existsSync(buildDir)) {
+  sourceDir = buildDir;
+}
+
+if (!sourceDir) {
+  console.error('Error: No dashboard build output found. Please run `npm run build` in the dashboard directory.');
+  process.exit(1);
+}
+
+const destDir = path.join(rootDir, 'public', 'dashboard');
+
+if (fs.existsSync(destDir)) {
+  fs.rmSync(destDir, { recursive: true, force: true });
+}
+
+fs.mkdirSync(destDir, { recursive: true });
+
+try {
+  // Use child_process to leverage system copy command for portability
+  if (process.platform === 'win32') {
+    execSync(`xcopy "${sourceDir}" "${destDir}" /E /I /Y`);
+  } else {
+    execSync(`cp -R ${sourceDir}/. ${destDir}`);
+  }
+  console.log(`Dashboard deployed: ${sourceDir} -> ${destDir}`);
+} catch (err) {
+  console.error('Error copying dashboard build output:', err.message);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add a deploy-dashboard.js helper to copy dashboard build output into `public/dashboard`
- expose as `npm run deploy:dashboard` in package.json

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854d0a1da08832394299a5f0efaffcb