### PR TITLE
Add dashboard deploy script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,6 @@ dist
 firebase-service-account.json
 serviceAccountKey.json
 *.service-account.json
+
+# Dashboard build output
+public/dashboard/


### PR DESCRIPTION
## Summary
- add a deploy script for dashboard hosting
- ignore `public/dashboard` build output

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854d89d75148323ba167c3592708884