### PR TITLE
Add live setup deploy script

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "resolve-package-conflicts": "node scripts/packageConflictResolver.js",
     "deploy:dashboard": "node scripts/deploy-dashboard.js",
     "setup:firebase": "node scripts/firebase-setup.js",
-    "deploy": "node scripts/deploy-to-firebase.js",
-    "setup:live": "node scripts/setup-and-deploy-live.js"
+    "setup:live": "node scripts/setup-and-deploy-live.js",
+    "deploy": "node scripts/deploy-to-firebase.js"
   },
   "keywords": [
     "AI",

--- a/scripts/setup-and-deploy-live.js
+++ b/scripts/setup-and-deploy-live.js
@@ -1,40 +1,16 @@
 #!/usr/bin/env node
 
 const { execSync } = require('child_process');
-const path = require('path');
 
-const color = {
-  red: text => `\x1b[31m${text}\x1b[0m`,
-  green: text => `\x1b[32m${text}\x1b[0m`,
-  yellow: text => `\x1b[33m${text}\x1b[0m`,
-  cyan: text => `\x1b[36m${text}\x1b[0m`,
-  magenta: text => `\x1b[35m${text}\x1b[0m`,
-};
-
-function log(colorFn, message) {
-  console.log(colorFn(message));
+function run(command, banner) {
+  console.log(`\n${banner}`);
+  execSync(command, { stdio: 'inherit' });
 }
 
-function run(command, description) {
-  try {
-    log(color.cyan, `\n➡ ${description}...`);
-    execSync(command, { stdio: 'inherit' });
-    log(color.green, `✅ ${description} complete.`);
-  } catch (err) {
-    log(color.red, `❌ ${description} failed.`);
-    process.exit(1);
-  }
+try {
+  run('npm run setup:firebase', '🔥 Setting up Firebase');
+  run('npm run deploy:dashboard', '📦 Building and staging dashboard');
+  run('npm run deploy', '🚀 Deploying to Firebase Hosting');
+} catch (err) {
+  process.exitCode = 1;
 }
-
-// Ensure we run from repository root
-const rootDir = path.resolve(__dirname, '..');
-process.chdir(rootDir);
-
-log(color.magenta, '\n🚀 Full Live Setup & Deployment\n');
-
-run('node scripts/firebase-setup.js', 'Firebase setup');
-run('node scripts/deploy-dashboard.js', 'Dashboard build');
-run('firebase deploy --only hosting', 'Firebase Hosting deploy');
-run('firebase open hosting:site', 'Opening live site');
-
-log(color.green, '\n🎉 Live site should now be open!\n');


### PR DESCRIPTION
## Summary
- create a live setup and deploy helper
- reorder the setup:live script entry in `package.json`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6854eef30888832399b88065211008a7