### PR TITLE
Fix setup:live script path

### DIFF
--- a/scripts/setup-and-deploy-live.js
+++ b/scripts/setup-and-deploy-live.js
@@ -52,7 +52,7 @@ process.chdir(rootDir);
 
 log(color.magenta, '\n🚀 Live Setup & Deployment Pipeline');
 
-run('node scripts/firebase-setup.js', 'Firebase setup');
+run('npm run setup:firebase', 'Firebase setup');
 run('npm --prefix dashboard run build', 'Building dashboard with Vite');
 
 const deployOutput = run('firebase deploy --only hosting', 'Deploying to Firebase Hosting', { capture: true });


### PR DESCRIPTION
## Summary
- call `npm run setup:firebase` inside setup-and-deploy-live script

## Testing
- `npm test`
- `npm run lint`
- `npm run setup:live` *(fails to authenticate to Firebase due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6854f18439a08323bf2a805356055678