### PR TITLE
Enhance deployment pipeline

### DIFF
--- a/scripts/setup-and-deploy-live.js
+++ b/scripts/setup-and-deploy-live.js
@@ -2,7 +2,11 @@
 console.log("\ud83d\ude80 Live deploy script initialized");
 
 const { execSync } = require('child_process');
+const fs = require('fs');
 const path = require('path');
+
+const rootDir = path.resolve(__dirname, '..');
+process.chdir(rootDir);
 
 const color = {
   red: text => `\x1b[31m${text}\x1b[0m`,
@@ -83,9 +87,60 @@ async function ensureFirebaseCLI() {
   runStep('Install Firebase CLI', 'npm install -g firebase-tools', { retries: 2 });
 }
 
+function ensureHostingPath() {
+  const firebasePath = path.join(rootDir, 'firebase.json');
+  if (!fs.existsSync(firebasePath)) return;
+  try {
+    const config = JSON.parse(fs.readFileSync(firebasePath, 'utf8'));
+    const current = config.hosting && config.hosting.public;
+    if (current !== 'public/dashboard') {
+      log(color.yellow, `⚠️  Hosting path mismatch: ${current} → public/dashboard`);
+      config.hosting = config.hosting || {};
+      const before = current || 'undefined';
+      config.hosting.public = 'public/dashboard';
+      fs.writeFileSync(firebasePath, JSON.stringify(config, null, 2));
+      log(color.yellow, `Updated hosting path: ${before} → ${config.hosting.public}`);
+    }
+  } catch {
+    log(color.red, '❌ Failed to verify firebase.json');
+  }
+}
+
+function copyToClipboard(text) {
+  try {
+    if (process.platform === 'darwin') {
+      execSync(`printf "${text}" | pbcopy`);
+    } else if (process.platform === 'win32') {
+      execSync(`echo ${text} | clip`, { shell: 'cmd.exe' });
+    }
+    log(color.green, '📋 URL copied to clipboard.');
+  } catch {
+    log(color.yellow, '⚠️  Failed to copy URL to clipboard.');
+  }
+}
+
+function parseViteOutput(output) {
+  const files = [];
+  const gzipSizes = {};
+  let duration = null;
+  const lines = output.split(/\r?\n/);
+  for (const line of lines) {
+    const durMatch = line.match(/Built(?: completed)?(?: in)?\s*([0-9.]+\w+)/i);
+    if (durMatch) duration = durMatch[1];
+    const fileMatch = line.trim().match(/([^\s]+\.(?:js|css|html))\s+([0-9.]+\s*\wB)(?:.*gzip:\s*([0-9.]+\s*\wB))?/);
+    if (fileMatch) {
+      const name = fileMatch[1];
+      files.push(name);
+      if (fileMatch[3]) gzipSizes[name] = fileMatch[3];
+    }
+  }
+  return { duration, files, gzipSizes };
+}
+
 function openUrl(url) {
   try {
-    log(color.green, `\n🌐 Deployed site: ${url}`);
+    log(color.green, `\n🌐 View Live: ${url}`);
+    copyToClipboard(url);
     log(color.cyan, `➡ Opening ${url}`);
     if (process.platform === 'win32') {
       execSync(`start ${url}`, { shell: 'cmd.exe' });
@@ -100,20 +155,32 @@ function openUrl(url) {
   }
 }
 
-const rootDir = path.resolve(__dirname, '..');
-process.chdir(rootDir);
-
 async function main() {
   log(color.magenta, '\n🚀 Live Setup & Deployment Pipeline');
 
   await ensureFirebaseCLI();
+
+  ensureHostingPath();
 
   if (!isLoggedIn()) {
     runStep('Firebase login', 'firebase login', { retries: 2 });
   }
 
   runStep('Firebase setup', 'npm run setup:firebase', { retryAuth: true, retries: 2 });
-  runStep('Deploy dashboard', 'npm run deploy:dashboard', { retryAuth: true, retries: 2 });
+  const dashboardOutput = runStep('Deploy dashboard', 'npm run deploy:dashboard', {
+    retryAuth: true,
+    retries: 2,
+    capture: true,
+  });
+  const buildInfo = parseViteOutput(dashboardOutput);
+  if (buildInfo.files.length) {
+    log(color.cyan, '\n📦 Vite Build Summary');
+    log(color.cyan, `   Duration: ${buildInfo.duration || 'unknown'}`);
+    buildInfo.files.forEach(f => {
+      const size = buildInfo.gzipSizes[f];
+      log(color.cyan, `   ${f}${size ? ` - gzip: ${size}` : ''}`);
+    });
+  }
   const deployOutput = runStep('Firebase deploy', 'npm run deploy', {
     capture: true,
     retryAuth: true,
@@ -125,7 +192,34 @@ async function main() {
     openUrl(url);
   }
 
-  log(color.green, '\n🎉 Deployment process finished!');
+  const timestamp = new Date().toISOString();
+  const logEntry = {
+    timestamp,
+    url,
+    files: buildInfo.files,
+    gzipSizes: buildInfo.gzipSizes,
+  };
+  const logPath = path.join(rootDir, 'deployment-log.json');
+  let logData = [];
+  if (fs.existsSync(logPath)) {
+    try { logData = JSON.parse(fs.readFileSync(logPath, 'utf8')); } catch {}
+  }
+  logData.push(logEntry);
+  fs.writeFileSync(logPath, JSON.stringify(logData, null, 2));
+
+  if (fs.existsSync(path.join(rootDir, '.git'))) {
+    try {
+      exec('git add -A');
+      exec(`git commit -m "chore: deployed ${timestamp}"`);
+      const tag = `deploy-${timestamp.replace(/[-:]/g, '').slice(0,13)}`;
+      exec(`git tag ${tag}`);
+      log(color.green, `Git commit and tag ${tag} created.`);
+    } catch {
+      log(color.yellow, '⚠️  Git commit or tag failed.');
+    }
+  }
+
+  log(color.green, `\n✅ Deployment completed at ${timestamp}`);
 }
 
 main().catch(() => {


### PR DESCRIPTION
## Summary
- improve `setup-and-deploy-live` script
  - enforce hosting path
  - show Vite build summary
  - copy deployed URL to clipboard
  - append deployment log
  - tag deployments

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68550a06f0dc832396feff5db2baa7d1