### PR TITLE
Implement deployment log rotation

### DIFF
--- a/scripts/deploy-to-firebase.js
+++ b/scripts/deploy-to-firebase.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 const { execSync } = require('child_process');
 const path = require('path');
+const { logDeployment } = require('./deploymentLogger');
 
 function logSuccess(msg) {
   console.log(`\x1b[32m✅ ${msg}\x1b[0m`);
@@ -27,6 +28,7 @@ try {
   logSuccess('Dashboard build step complete.');
 } catch (err) {
   logFailure(`Failed to deploy dashboard: ${err.message}`);
+  logDeployment({ timestamp: new Date().toISOString(), success: false, error: err.message });
   process.exit(1);
 }
 
@@ -36,12 +38,15 @@ try {
   const match = output.match(/Hosting URL[:\s]+(https?:\/\/[^\s]+)/i);
   if (match) {
     logSuccess(`Firebase Hosting deployed at ${match[1]}`);
+    logDeployment({ timestamp: new Date().toISOString(), success: true, url: match[1] });
   } else {
     logSuccess('Firebase Hosting deployment complete.');
+    logDeployment({ timestamp: new Date().toISOString(), success: true });
   }
 } catch (err) {
   logFailure(`Firebase deploy failed: ${err.message}`);
   if (err.stdout) console.error(err.stdout.toString());
   if (err.stderr) console.error(err.stderr.toString());
+  logDeployment({ timestamp: new Date().toISOString(), success: false, error: err.message });
   process.exit(1);
 }

--- a/scripts/deploymentLogger.js
+++ b/scripts/deploymentLogger.js
@@ -1,0 +1,42 @@
+const fs = require('fs');
+const path = require('path');
+
+const DEPLOY_DIR = path.join(__dirname, '..', 'logs', 'deployments');
+const INDEX_FILE = path.join(DEPLOY_DIR, 'index.json');
+
+function readJson(file, fallback) {
+  try {
+    if (!fs.existsSync(file)) return fallback;
+    const data = fs.readFileSync(file, 'utf8');
+    return JSON.parse(data);
+  } catch {
+    return fallback;
+  }
+}
+
+function writeJson(file, data) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, JSON.stringify(data, null, 2));
+}
+
+function updateIndex() {
+  if (!fs.existsSync(DEPLOY_DIR)) return;
+  const files = fs.readdirSync(DEPLOY_DIR)
+    .filter(f => f.endsWith('.json') && f !== 'index.json');
+  const index = files.map(f => {
+    const entries = readJson(path.join(DEPLOY_DIR, f), []);
+    return { date: path.basename(f, '.json'), count: entries.length };
+  }).sort((a, b) => b.date.localeCompare(a.date));
+  writeJson(INDEX_FILE, index);
+}
+
+function logDeployment(entry) {
+  const date = new Date().toISOString().slice(0, 10);
+  const file = path.join(DEPLOY_DIR, `${date}.json`);
+  const logs = readJson(file, []);
+  logs.push(entry);
+  writeJson(file, logs);
+  updateIndex();
+}
+
+module.exports = { logDeployment };

--- a/scripts/setup-and-deploy-live.js
+++ b/scripts/setup-and-deploy-live.js
@@ -5,6 +5,7 @@ const { execSync } = require('child_process');
 const path = require('path');
 const fs = require('fs');
 const clipboardy = require('clipboardy');
+const { logDeployment } = require('./deploymentLogger');
 
 const color = {
   red: text => `\x1b[31m${text}\x1b[0m`,
@@ -164,9 +165,11 @@ async function main() {
     log(color.green, `URL: ${url}`);
   }
   log(color.green, `Directory used: ${hostingDir}`);
+  logDeployment({ timestamp, success: true, url, directory: hostingDir });
 }
 
-main().catch(() => {
+main().catch(err => {
   log(color.red, '\n🔥 Setup & deployment process terminated due to errors.');
+  logDeployment({ timestamp: new Date().toISOString(), success: false, error: err.message });
   process.exit(1);
 });


### PR DESCRIPTION
## Summary
- log deployments with new deploymentLogger utility
- record deploy outcome in daily files and update deployment index

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68550b922e8c832381949b9998c76db9