### PR TITLE
Add Cloud Run post-deployment script

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "deploy:dashboard": "node scripts/deploy-dashboard.js",
     "deploy": "node scripts/deploy-to-firebase.js",
     "validate:rules": "node scripts/validate-security-rules.js",
-    "setup:live": "node scripts/setup-and-deploy-live.js"
+    "setup:live": "node scripts/setup-and-deploy-live.js",
+    "postdeploy:cloudrun": "node scripts/cloudrun-postdeploy.js"
   },
   "keywords": [
     "AI",

--- a/scripts/cloudrun-postdeploy.js
+++ b/scripts/cloudrun-postdeploy.js
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+function logSuccess(msg) {
+  console.log(`\x1b[32m✅ ${msg}\x1b[0m`);
+}
+
+function logFailure(msg) {
+  console.error(`\x1b[31m❌ ${msg}\x1b[0m`);
+}
+
+function logInfo(msg) {
+  console.log(`\x1b[34mℹ️  ${msg}\x1b[0m`);
+}
+
+const SERVICE = process.env.SERVICE_NAME;
+const REGION = process.env.REGION;
+const PROJECT = process.env.PROJECT_ID;
+const WEBHOOK = process.env.SLACK_WEBHOOK_URL || process.env.WEBHOOK_URL;
+
+if (!SERVICE || !REGION) {
+  logFailure('SERVICE_NAME and REGION environment variables are required.');
+  process.exit(1);
+}
+
+const rootDir = path.resolve(__dirname, '..');
+if (process.cwd() !== rootDir) {
+  process.chdir(rootDir);
+}
+
+const DEPLOY_LOG = path.join(rootDir, 'logs', 'deployments.json');
+
+function readLog() {
+  try {
+    return JSON.parse(fs.readFileSync(DEPLOY_LOG, 'utf8'));
+  } catch {
+    return [];
+  }
+}
+
+function writeLog(data) {
+  fs.mkdirSync(path.dirname(DEPLOY_LOG), { recursive: true });
+  fs.writeFileSync(DEPLOY_LOG, JSON.stringify(data, null, 2));
+}
+
+async function postToWebhook(message) {
+  if (!WEBHOOK) return;
+  try {
+    await fetch(WEBHOOK, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text: message })
+    });
+  } catch (err) {
+    logFailure(`Failed to notify webhook: ${err.message}`);
+  }
+}
+
+function getServiceUrl() {
+  return execSync(`gcloud run services describe ${SERVICE} --region ${REGION} --format="value(status.url)"`, { encoding: 'utf8' }).trim();
+}
+
+function getRevisions() {
+  const out = execSync(`gcloud run revisions list --service ${SERVICE} --region ${REGION} --sort-by \"~createTime\" --limit 2 --format=json`, { encoding: 'utf8' });
+  return JSON.parse(out).map(r => r.metadata.name);
+}
+
+function rollbackTo(revision) {
+  execSync(`gcloud run services update-traffic ${SERVICE} --region ${REGION} --to-revisions ${revision}=100`, { stdio: 'inherit' });
+}
+
+(async () => {
+  const commit = execSync('git rev-parse HEAD', { encoding: 'utf8' }).trim();
+  const url = getServiceUrl();
+  const logEntry = {
+    timestamp: new Date().toISOString(),
+    commit,
+    url
+  };
+
+  logInfo(`Pinging ${url}/health ...`);
+  let healthy = false;
+  try {
+    const res = await fetch(`${url}/health`);
+    healthy = res.ok;
+  } catch (err) {
+    logFailure(`Health check request failed: ${err.message}`);
+  }
+
+  if (healthy) {
+    logSuccess('Health check passed');
+    logEntry.status = 'healthy';
+  } else {
+    logFailure('Health check failed, rolling back...');
+    logEntry.status = 'rollback';
+    const revs = getRevisions();
+    if (revs.length > 1) {
+      try {
+        rollbackTo(revs[1]);
+        logSuccess(`Rolled back to ${revs[1]}`);
+        await postToWebhook(`Rolled back ${SERVICE} to ${revs[1]} after failed health check.`);
+      } catch (err) {
+        logFailure(`Rollback failed: ${err.message}`);
+        logEntry.error = err.message;
+      }
+    } else {
+      logFailure('No previous revision found to rollback to.');
+      logEntry.error = 'No previous revision';
+    }
+  }
+
+  const data = readLog();
+  data.push(logEntry);
+  writeLog(data);
+})();
+


### PR DESCRIPTION
## Summary
- add `cloudrun-postdeploy.js` for post-deploy health checks and rollback
- wire the script in as `npm run postdeploy:cloudrun`

## Testing
- `npm test`
- `SERVICE_NAME=test REGION=us-central1 node scripts/cloudrun-postdeploy.js` *(fails: gcloud not found)*

------
https://chatgpt.com/codex/tasks/task_e_685518d8f5c08323b0ec3539edc5e3b8