### PR TITLE
Add deployment summary generator and API

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,41 @@
 const express = require('express');
+const fs = require('fs');
+const path = require('path');
+const { exec } = require('child_process');
 const app = express();
 
 const PORT = process.env.PORT || 8080;
 
 app.get('/', (req, res) => {
   res.send('AI Agent Systems API running');
+});
+
+const SUMMARY_FILE = path.join(__dirname, 'logs', 'summary.json');
+
+function loadSummary() {
+  try {
+    return JSON.parse(fs.readFileSync(SUMMARY_FILE, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+app.get('/api/summary', (req, res) => {
+  const data = loadSummary();
+  if (!data) {
+    return res.status(503).json({ error: 'Summary unavailable' });
+  }
+  res.json(data);
+});
+
+app.post('/api/refresh', (req, res) => {
+  exec('npm run postdeploy:all', { cwd: __dirname }, () => {
+    const data = loadSummary();
+    if (!data) {
+      return res.status(503).json({ error: 'Summary unavailable' });
+    }
+    res.json(data);
+  });
 });
 
 app.listen(PORT, () => {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "validate:rules": "node scripts/validate-security-rules.js",
     "setup:live": "node scripts/setup-and-deploy-live.js",
     "postdeploy:cloudrun": "node scripts/cloudrun-postdeploy.js",
-    "postdeploy:summary": "node scripts/postDeploySummary.js"
+    "postdeploy:summary": "node scripts/postDeploySummary.js",
+    "postdeploy:all": "node scripts/postDeploySummary.js"
   },
   "keywords": [
     "AI",


### PR DESCRIPTION
## Summary
- implement new `postDeploySummary.js` to compile deployment info and agent status
- expose `/api/summary` and `/api/refresh` endpoints
- add `postdeploy:all` npm script

## Testing
- `npm test`
- `node scripts/postDeploySummary.js`
- `npm start` then `curl http://localhost:8080/api/summary`
- `curl -X POST http://localhost:8080/api/refresh`

------
https://chatgpt.com/codex/tasks/task_e_68551d5bf2388323becc9e5417f1376c