### PR TITLE
Fix landing page routing

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,12 +56,10 @@ app.post('/api/refresh', (req, res) => {
   });
 });
 
-// Landing page served for the root and unmatched routes
+// Public landing page
+// Serve the Vite built index.html at the root while allowing
+// static assets like JS and CSS to resolve correctly
 app.get('/', (req, res) => {
-  res.sendFile(path.join(frontendDir, 'index.html'));
-});
-
-app.get('*', (req, res) => {
   res.sendFile(path.join(frontendDir, 'index.html'));
 });
 


### PR DESCRIPTION
## Summary
- serve dist assets statically
- send the Vite-built landing page at the root route

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855be583e1083238b9d90cd608e8777