### PR TITLE
Fix Cloud Run container startup timeout for Express app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ COPY . .
 RUN npm run build --prefix frontend
 
 EXPOSE 8080
-CMD ["npm", "start"]
+CMD ["node", "index.js"]

--- a/index.js
+++ b/index.js
@@ -7,6 +7,11 @@ const PORT = process.env.PORT || 8080;
 const distDir = path.join(__dirname, 'frontend', 'dist');
 app.use(express.static(distDir));
 
+// Health check endpoint for Cloud Run
+app.get('/healthz', (_req, res) => {
+  res.status(200).send('OK');
+});
+
 // Serve the frontend entry for any route not matched by static assets
 app.get('*', (_req, res) => {
   res.sendFile(path.join(distDir, 'index.html'));


### PR DESCRIPTION
## Summary
- expose a `/healthz` endpoint in `index.js`
- launch server with `node index.js` in Dockerfile

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855d717b5808323ae243c8ce0b30a7b