### PR TITLE
Fix Express fallback route

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ app.get('/healthz', (_req, res) => {
 });
 
 // Serve the frontend entry for any route not matched by static assets
-app.get('*', (_req, res) => {
+app.get(/.*/, (_req, res) => {
   res.sendFile(path.join(distDir, 'index.html'));
 });
 


### PR DESCRIPTION
## Summary
- use regex fallback to avoid Cloud Run crash

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6855d88236b083239cb1e29ff8d0a5b0