### PR TITLE
Finalize Cloud Run deployment

### DIFF
--- a/DEPLOYMENT_OVERVIEW.md
+++ b/DEPLOYMENT_OVERVIEW.md
@@ -38,7 +38,7 @@ The Dockerfile builds the React frontend during the container build so the `/` r
  - `/` – Serves the Vite-built landing page (Cloud Run loads this by default).
 - `/dashboard` – Governance dashboard UI.
 - `/api/summary` – Returns the latest deployment summary from `logs/summary.json`.
-- `/health-check` – Basic service health endpoint.
+ - `/healthz` – Basic service health endpoint used by Cloud Run.
 - `/reports/*` – Generated PDF reports.
 
 ## Update Flow

--- a/scripts/cloudrun-postdeploy.js
+++ b/scripts/cloudrun-postdeploy.js
@@ -80,10 +80,10 @@ function rollbackTo(revision) {
     url
   };
 
-  logInfo(`Pinging ${url}/health ...`);
+  logInfo(`Pinging ${url}/healthz ...`);
   let healthy = false;
   try {
-    const res = await fetch(`${url}/health`);
+    const res = await fetch(`${url}/healthz`);
     healthy = res.ok;
   } catch (err) {
     logFailure(`Health check request failed: ${err.message}`);


### PR DESCRIPTION
## Summary
- update health check route references in deployment docs
- adjust postdeploy script to check `/healthz`

## Testing
- `npm test`
- `node scripts/validate-dockerfile.js`
- `curl -I https://ai-agent-systems-p3huz7b3lq-uc.a.run.app` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6855dc2efe208323a5830001d2fc9564