### PR TITLE
Add agent console visualizer

### DIFF
--- a/frontend/AgentConsoleView.jsx
+++ b/frontend/AgentConsoleView.jsx
@@ -1,0 +1,54 @@
+import React, { useState, useEffect } from 'react';
+
+export default function AgentConsoleView() {
+  const [logs, setLogs] = useState([]);
+  const [agents, setAgents] = useState([
+    { id: 'insights-agent', label: 'Insights', status: 'idle' },
+    { id: 'trends-agent', label: 'Trends', status: 'idle' },
+    { id: 'strategy-agent', label: 'Strategy', status: 'idle' },
+    { id: 'report-agent', label: 'Report', status: 'idle' },
+  ]);
+
+  useEffect(() => {
+    const eventSource = new EventSource('/api/agent-logs');
+    eventSource.onmessage = e => {
+      const msg = JSON.parse(e.data);
+      setLogs(prev => [...prev.slice(-50), msg.log]);
+      setAgents(prev =>
+        prev.map(agent =>
+          agent.id === msg.agent ? { ...agent, status: msg.status } : agent
+        )
+      );
+    };
+    return () => eventSource.close();
+  }, []);
+
+  return (
+    <div className="grid grid-cols-2 gap-4 p-4">
+      <div className="bg-black text-green-400 text-xs font-mono p-3 rounded-xl max-h-60 overflow-y-auto">
+        {logs.map((line, idx) => (
+          <div key={idx} className="whitespace-pre-wrap">{line}</div>
+        ))}
+      </div>
+
+      <div className="relative w-full h-60 bg-purple-900 rounded-xl flex items-center justify-around">
+        {agents.map(agent => (
+          <div key={agent.id} className="flex flex-col items-center text-white">
+            <div
+              className={`w-4 h-4 mb-2 rounded-full animate-ping ${
+                agent.status === 'working'
+                  ? 'bg-blue-400'
+                  : agent.status === 'done'
+                    ? 'bg-green-400'
+                    : 'bg-gray-400'
+              }`}
+            />
+            <div className="text-sm">{agent.label}</div>
+          </div>
+        ))}
+
+        {/* Visual connector arcs go here in Prompt 2 */}
+      </div>
+    </div>
+  );
+}

--- a/frontend/LandingPage.jsx
+++ b/frontend/LandingPage.jsx
@@ -3,6 +3,7 @@ import {
   Globe, Zap, Brain, FileText, CheckCircle, ArrowRight, Users, TrendingUp, Clock, Shield, Star, ChevronDown, Play, Pause, RotateCcw
 } from 'lucide-react';
 import AgentTracker from './AgentTracker';
+import AgentConsoleView from './AgentConsoleView';
 
 const LandingPage = () => {
   const [currentStep, setCurrentStep] = useState(0);
@@ -142,11 +143,18 @@ const LandingPage = () => {
                 </>
               )}
               {isAnalyzing && (
-                <AgentTracker
-                  steps={analysisSteps.map(s => s.title)}
-                  currentStep={currentStep}
-                  status={stepStatus}
-                />
+                <>
+                  <AgentTracker
+                    steps={analysisSteps.map(s => s.title)}
+                    currentStep={currentStep}
+                    status={stepStatus}
+                  />
+                  {currentStep === 0 && (
+                    <div className="mt-4">
+                      <AgentConsoleView />
+                    </div>
+                  )}
+                </>
               )}
               {analysisComplete && emailSent && (
                 <div className="mt-4 flex flex-col items-center">

--- a/frontend/src/AgentConsoleView.jsx
+++ b/frontend/src/AgentConsoleView.jsx
@@ -1,0 +1,54 @@
+import React, { useState, useEffect } from 'react';
+
+export default function AgentConsoleView() {
+  const [logs, setLogs] = useState([]);
+  const [agents, setAgents] = useState([
+    { id: 'insights-agent', label: 'Insights', status: 'idle' },
+    { id: 'trends-agent', label: 'Trends', status: 'idle' },
+    { id: 'strategy-agent', label: 'Strategy', status: 'idle' },
+    { id: 'report-agent', label: 'Report', status: 'idle' },
+  ]);
+
+  useEffect(() => {
+    const eventSource = new EventSource('/api/agent-logs');
+    eventSource.onmessage = e => {
+      const msg = JSON.parse(e.data);
+      setLogs(prev => [...prev.slice(-50), msg.log]);
+      setAgents(prev =>
+        prev.map(agent =>
+          agent.id === msg.agent ? { ...agent, status: msg.status } : agent
+        )
+      );
+    };
+    return () => eventSource.close();
+  }, []);
+
+  return (
+    <div className="grid grid-cols-2 gap-4 p-4">
+      <div className="bg-black text-green-400 text-xs font-mono p-3 rounded-xl max-h-60 overflow-y-auto">
+        {logs.map((line, idx) => (
+          <div key={idx} className="whitespace-pre-wrap">{line}</div>
+        ))}
+      </div>
+
+      <div className="relative w-full h-60 bg-purple-900 rounded-xl flex items-center justify-around">
+        {agents.map(agent => (
+          <div key={agent.id} className="flex flex-col items-center text-white">
+            <div
+              className={`w-4 h-4 mb-2 rounded-full animate-ping ${
+                agent.status === 'working'
+                  ? 'bg-blue-400'
+                  : agent.status === 'done'
+                    ? 'bg-green-400'
+                    : 'bg-gray-400'
+              }`}
+            />
+            <div className="text-sm">{agent.label}</div>
+          </div>
+        ))}
+
+        {/* Visual connector arcs go here in Prompt 2 */}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/LandingPage.jsx
+++ b/frontend/src/LandingPage.jsx
@@ -3,6 +3,7 @@ import {
   Globe, Zap, Brain, FileText, CheckCircle, ArrowRight, Users, TrendingUp, Clock, Shield, Star, ChevronDown, Play, Pause, RotateCcw
 } from 'lucide-react';
 import AgentTracker from './AgentTracker';
+import AgentConsoleView from './AgentConsoleView';
 
 const LandingPage = () => {
   const [currentStep, setCurrentStep] = useState(0);
@@ -142,11 +143,18 @@ const LandingPage = () => {
                 </>
               )}
               {isAnalyzing && (
-                <AgentTracker
-                  steps={analysisSteps.map(s => s.title)}
-                  currentStep={currentStep}
-                  status={stepStatus}
-                />
+                <>
+                  <AgentTracker
+                    steps={analysisSteps.map(s => s.title)}
+                    currentStep={currentStep}
+                    status={stepStatus}
+                  />
+                  {currentStep === 0 && (
+                    <div className="mt-4">
+                      <AgentConsoleView />
+                    </div>
+                  )}
+                </>
               )}
               {analysisComplete && emailSent && (
                 <div className="mt-4 flex flex-col items-center">


### PR DESCRIPTION
## Summary
- add AgentConsoleView component to show live agent logs and status
- display live console during Website Analysis step

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855dd2dd3988323b744e677e5099a1a