### PR TITLE
Add real-time log feed to landing page

### DIFF
--- a/frontend/src/LandingPage.jsx
+++ b/frontend/src/LandingPage.jsx
@@ -1,4 +1,6 @@
 import React, { useState, useEffect } from 'react';
+import { collection, onSnapshot, query, orderBy } from 'firebase/firestore';
+import { db } from './firebase';
 import {
   Globe, Zap, Brain, FileText, CheckCircle, ArrowRight, Users, TrendingUp, Clock, Shield, Star, ChevronDown, Play, Pause, RotateCcw
 } from 'lucide-react';
@@ -80,19 +82,26 @@ const LandingPage = () => {
     setStepStatus(analysisSteps.map((_, i) => (i === 0 ? 'active' : 'pending')));
   };
 
-  // Simulate agent collaboration log messages when analyzing
+  // Listen to Firestore logs in real time
+  const subscribeToLogs = () => {
+    const q = query(collection(db, 'logs'), orderBy('timestamp'));
+    return onSnapshot(q, snap => {
+      snap.docChanges().forEach(change => {
+        if (change.type === 'added') {
+          const data = change.doc.data();
+          const msg = data.message || data.outputSnippet || data.output || '';
+          setLogMessages(prev => [...prev, msg]);
+        }
+      });
+    });
+  };
+
   useEffect(() => {
     if (!isAnalyzing) return;
-    const msgs = [
-      '[insights-agent] Sending data to [trends-agent]',
-      '[forecast-agent] requesting anomaly-agent support...'
-    ];
-    let i = 0;
-    const interval = setInterval(() => {
-      setLogMessages((logs) => [...logs, msgs[i % msgs.length]]);
-      i++;
-    }, 3000);
-    return () => clearInterval(interval);
+    const unsub = subscribeToLogs();
+    return () => {
+      if (unsub) unsub();
+    };
   }, [isAnalyzing]);
 
   useEffect(() => {

--- a/frontend/src/firebase.js
+++ b/frontend/src/firebase.js
@@ -1,0 +1,11 @@
+import { initializeApp } from 'firebase/app';
+import { getFirestore } from 'firebase/firestore';
+
+const firebaseConfig = {
+  apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
+  authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN,
+  projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID,
+};
+
+const app = initializeApp(firebaseConfig);
+export const db = getFirestore(app);


### PR DESCRIPTION
## Summary
- connect LandingPage to Firestore
- stream log messages in real time when analyzing
- expose firebase configuration for the frontend

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855e355df688323b359a2a3e48e559c