### PR TITLE
Add AgentHealthDashboard React component

### DIFF
--- a/dashboard/src/App.jsx
+++ b/dashboard/src/App.jsx
@@ -3,6 +3,7 @@ import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom';
 import AgentStatusTable from './components/AgentStatusTable';
 import MisalignmentProposalsPanel from './components/MisalignmentProposalsPanel';
 import ExecutionLogViewer from './components/ExecutionLogViewer';
+import AgentHealthDashboard from './components/AgentHealthDashboard';
 import './index.css';
 
 export default function App() {
@@ -21,6 +22,7 @@ export default function App() {
         <aside className="w-48 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 p-4 flex flex-col">
           <nav className="flex flex-col space-y-2 flex-1">
             <Link to="/" className="hover:underline">Status</Link>
+            <Link to="/health" className="hover:underline">Health</Link>
             <Link to="/proposals" className="hover:underline">Proposals</Link>
             <Link to="/logs" className="hover:underline">Logs</Link>
           </nav>
@@ -31,6 +33,7 @@ export default function App() {
         <main className="flex-1 overflow-auto">
           <Routes>
             <Route path="/" element={<AgentStatusTable />} />
+            <Route path="/health" element={<AgentHealthDashboard />} />
             <Route path="/proposals" element={<MisalignmentProposalsPanel />} />
             <Route path="/logs" element={<ExecutionLogViewer />} />
           </Routes>

--- a/dashboard/src/components/AgentHealthDashboard.jsx
+++ b/dashboard/src/components/AgentHealthDashboard.jsx
@@ -1,0 +1,118 @@
+import { useEffect, useState } from 'react';
+import { collection, getDocs, query, where, orderBy, limit } from 'firebase/firestore';
+import { RefreshCw, CheckCircle, AlertTriangle } from 'lucide-react';
+import { db } from '../firebase';
+
+function relativeTime(date) {
+  if (!date) return '-';
+  const ts = date instanceof Date ? date.getTime() : date.toDate ? date.toDate().getTime() : new Date(date).getTime();
+  const diff = Date.now() - ts;
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins} mins ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs} hrs ago`;
+  const days = Math.floor(hrs / 24);
+  return `${days}d ago`;
+}
+
+function alignColor(score) {
+  if (score >= 80) return 'text-green-400';
+  if (score >= 50) return 'text-yellow-400';
+  return 'text-red-400';
+}
+
+async function notifySlack(agent) {
+  const url = import.meta.env.VITE_SLACK_WEBHOOK_URL;
+  if (!url) return;
+  try {
+    await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text: `Agent ${agent} failed 3 times in a row` })
+    });
+  } catch {
+    /* ignore */
+  }
+}
+
+export default function AgentHealthDashboard() {
+  const [agents, setAgents] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  const fetchData = async () => {
+    setLoading(true);
+    const snap = await getDocs(collection(db, 'agent-metadata'));
+    const since = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    const result = [];
+    for (const docSnap of snap.docs) {
+      const data = docSnap.data();
+      let errorCount = 0;
+      try {
+        const logQ = query(
+          collection(db, 'logs'),
+          where('agent', '==', docSnap.id),
+          where('timestamp', '>=', since)
+        );
+        const logSnap = await getDocs(logQ);
+        errorCount = logSnap.docs.filter(d => d.data().error).length;
+
+        const failQ = query(
+          collection(db, 'logs'),
+          where('agent', '==', docSnap.id),
+          orderBy('timestamp', 'desc'),
+          limit(3)
+        );
+        const failSnap = await getDocs(failQ);
+        if (failSnap.docs.length === 3 && failSnap.docs.every(d => d.data().error)) {
+          notifySlack(docSnap.id);
+        }
+      } catch {
+        /* ignore */
+      }
+      result.push({ id: docSnap.id, ...data, errorCount });
+    }
+    setAgents(result);
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, []);
+
+  return (
+    <div className="p-4">
+      <div className="flex items-center mb-4">
+        <h2 className="text-2xl font-semibold text-white flex-1">Agent Health</h2>
+        <button
+          onClick={fetchData}
+          className="flex items-center text-sm bg-slate-700 text-white px-3 py-1 rounded"
+        >
+          <RefreshCw className="w-4 h-4 mr-1" /> Refresh
+        </button>
+      </div>
+      {loading ? (
+        <div className="text-white">Loading...</div>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {agents.map(a => (
+            <div key={a.id} className="bg-slate-800 rounded-xl p-4 text-white space-y-1">
+              <div className="flex items-center justify-between">
+                <div className="font-semibold">{a.name || a.id}</div>
+                <div className={a.status === 'online' ? 'text-green-400 flex items-center' : 'text-red-400 flex items-center'}>
+                  {a.status === 'online' ? <CheckCircle className="w-4 h-4 mr-1" /> : <AlertTriangle className="w-4 h-4 mr-1" />} {a.status || 'offline'}
+                </div>
+              </div>
+              <div className="text-sm">Last run: {relativeTime(a.lastRun)}</div>
+              <div className="text-sm">
+                Alignment: <span className={alignColor(a.alignmentScore)}>{a.alignmentScore != null ? `${a.alignmentScore}%` : '-'}</span>
+              </div>
+              <div className="text-sm">SOP v{a.sopVersion || '-'}</div>
+              <div className="text-sm">Errors (24h): {a.errorCount}</div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- include AgentHealthDashboard in dashboard React app
- display agent health info from Firestore in responsive cards
- add navigation link and route for new dashboard page

## Testing
- `npm test`
- `cd dashboard && npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6855e41c6c5c8323b8e69a66db96bc25