### PR TITLE
Implement PDF report generation endpoint

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -7,6 +7,7 @@ const multer = require('multer');
 const JSZip = require('jszip');
 const nodemailer = require('nodemailer');
 const PDFDocument = require('pdfkit');
+const { PDFDocument: PDFLibDocument, rgb, StandardFonts } = require('pdf-lib');
 const crypto = require('crypto');
 const loadAgents = require('./loadAgents');
 const agentMetadata = require('../agents/agent-metadata.json');
@@ -17,6 +18,7 @@ const {
 } = require('./auditLogger');
 const runHealthChecks = require('./healthCheck');
 const { reportSOP } = require('./sopReporter');
+const { admin } = require('../firebase');
 
 // Load environment variables from .env if present
 dotenv.config();
@@ -227,6 +229,90 @@ function getReportsForEmail(email) {
     }
   }
   return sessions;
+}
+
+async function fetchSessionLogsFromFirestore(sessionId) {
+  try {
+    const ref = admin.firestore().collection('logs').doc(sessionId);
+    const sub = await ref.collection('messages').orderBy('timestamp').get();
+    if (!sub.empty) return sub.docs.map(d => d.data());
+    const doc = await ref.get();
+    const data = doc.exists ? doc.data() : {};
+    return Array.isArray(data.logs) ? data.logs : Array.isArray(data.messages) ? data.messages : [];
+  } catch (err) {
+    console.error('Failed to read Firestore logs', err);
+    return [];
+  }
+}
+
+function groupLogsByStep(logs = []) {
+  const grouped = {};
+  for (const entry of logs) {
+    const step = entry.step || 'General';
+    if (!grouped[step]) grouped[step] = {};
+    const agent = entry.agent || 'unknown';
+    if (!grouped[step][agent]) grouped[step][agent] = [];
+    grouped[step][agent].push(entry);
+  }
+  return grouped;
+}
+
+async function createPdfReport(company, sessionId, logs) {
+  const grouped = groupLogsByStep(logs);
+  const pdfDoc = await PDFLibDocument.create();
+  const font = await pdfDoc.embedFont(StandardFonts.Helvetica);
+  const brand = rgb(0.294, 0.612, 0.886);
+
+  // Cover page
+  let page = pdfDoc.addPage();
+  let { width, height } = page.getSize();
+  page.drawText(company || 'AI Report', {
+    x: 50,
+    y: height - 80,
+    size: 30,
+    font,
+    color: brand,
+  });
+  page.drawText(`Session: ${sessionId}`, { x: 50, y: height - 120, size: 12, font });
+  page.drawText(`Generated: ${new Date().toLocaleDateString()}`, { x: 50, y: height - 140, size: 12, font });
+
+  // Step pages
+  for (const [step, agents] of Object.entries(grouped)) {
+    page = pdfDoc.addPage();
+    ({ width, height } = page.getSize());
+    let y = height - 40;
+    page.drawText(step, { x: 50, y, size: 20, font, color: brand });
+    y -= 30;
+    for (const [agent, entries] of Object.entries(agents)) {
+      page.drawText(agent, { x: 60, y, size: 14, font });
+      y -= 20;
+      for (const entry of entries) {
+        const msg = entry.output ? JSON.stringify(entry.output) : JSON.stringify(entry.input);
+        const text = msg.length > 400 ? msg.slice(0, 397) + '...' : msg;
+        page.drawText(text, { x: 70, y, size: 10, font, maxWidth: width - 80 });
+        y -= 14;
+        if (y < 40) { page = pdfDoc.addPage(); y = page.getHeight() - 40; }
+      }
+      y -= 10;
+    }
+  }
+
+  // Summary page
+  page = pdfDoc.addPage();
+  ({ width, height } = page.getSize());
+  let y = height - 40;
+  page.drawText('Summary', { x: 50, y, size: 20, font, color: brand });
+  y -= 30;
+  const recs = logs
+    .flatMap(l => Array.isArray(l.recommendations) ? l.recommendations : [])
+    .slice(0, 5);
+  recs.forEach((rec, i) => {
+    const text = `${i + 1}. ${rec}`;
+    page.drawText(text, { x: 60, y, size: 12, font, maxWidth: width - 80 });
+    y -= 16;
+  });
+
+  return await pdfDoc.save();
 }
 
 // Append request info to log file
@@ -704,6 +790,25 @@ app.get('/resume/:sessionId', (req, res) => {
   const status = sessions[sessionId] || [];
   const logs = getSessionLogs(sessionId);
   res.json({ status, logs });
+});
+
+// Generate PDF report from Firestore logs
+app.get('/generate-report/:sessionId', async (req, res) => {
+  const { sessionId } = req.params;
+  try {
+    const logs = await fetchSessionLogsFromFirestore(sessionId);
+    if (!logs.length) return res.status(404).json({ error: 'No logs found' });
+    const company = logs[0]?.clientName || 'Company';
+    const pdfBuffer = await createPdfReport(company, sessionId, logs);
+    const bucket = admin.storage().bucket();
+    const file = bucket.file(`reports/${sessionId}.pdf`);
+    await file.save(pdfBuffer, { contentType: 'application/pdf' });
+    const [url] = await file.getSignedUrl({ action: 'read', expires: Date.now() + 7 * 24 * 60 * 60 * 1000 });
+    res.json({ url });
+  } catch (err) {
+    console.error('Failed to generate report:', err);
+    res.status(500).json({ error: 'Failed to generate report' });
+  }
 });
 
 // LibreTranslate - available languages

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -13,7 +13,8 @@
         "express": "^5.1.0",
         "firebase-admin": "^11.10.1",
         "firebase-functions": "^6.3.2",
-        "nodemailer": "^6.9.1"
+        "nodemailer": "^6.9.1",
+        "pdf-lib": "^1.17.1"
       },
       "devDependencies": {
         "eslint": "^8.50.0"
@@ -455,6 +456,24 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@pdf-lib/standard-fonts": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/standard-fonts/-/standard-fonts-1.0.0.tgz",
+      "integrity": "sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.6"
+      }
+    },
+    "node_modules/@pdf-lib/upng": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/upng/-/upng-1.0.1.tgz",
+      "integrity": "sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.10"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -3474,6 +3493,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -3534,6 +3559,24 @@
       "engines": {
         "node": ">=16"
       }
+    },
+    "node_modules/pdf-lib": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/pdf-lib/-/pdf-lib-1.17.1.tgz",
+      "integrity": "sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@pdf-lib/standard-fonts": "^1.0.0",
+        "@pdf-lib/upng": "^1.0.1",
+        "pako": "^1.0.11",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/pdf-lib/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",

--- a/functions/package.json
+++ b/functions/package.json
@@ -13,7 +13,8 @@
     "express": "^5.1.0",
     "firebase-admin": "^11.10.1",
     "firebase-functions": "^6.3.2",
-    "nodemailer": "^6.9.1"
+    "nodemailer": "^6.9.1",
+    "pdf-lib": "^1.17.1"
   },
   "devDependencies": {
     "eslint": "^8.50.0"


### PR DESCRIPTION
## Summary
- add `pdf-lib` dependency for new PDF reports
- implement Firestore log retrieval helpers
- generate PDF summaries
- create `/generate-report/:sessionId` endpoint to save PDFs to Firebase Storage

## Testing
- `npm test`
- `npm test --prefix functions`

------
https://chatgpt.com/codex/tasks/task_e_6855e428d3708323ad9d93d4e218d5d4