### PR TITLE
Add agent registry and dynamic frontend

### DIFF
--- a/frontend/AgentsGallery.jsx
+++ b/frontend/AgentsGallery.jsx
@@ -1,32 +1,25 @@
-import React, { useState } from "react";
-
-const agents = [
-  {
-    id: "insights-agent",
-    name: "Content Insights Agent",
-    description: "Analyzes content engagement and suggests improvements.",
-    tags: ["Marketing", "Analytics"]
-  },
-  {
-    id: "website-scanner-agent",
-    name: "Website Scanner",
-    description: "Scrapes and summarizes your website structure.",
-    tags: ["Scraping", "Data Extraction"]
-  },
-  {
-    id: "market-research-agent",
-    name: "Market Research Agent",
-    description: "Analyzes industry and competitor trends.",
-    tags: ["Business", "Research"]
-  }
-];
+import React, { useState, useEffect } from "react";
 
 export default function AgentsGallery() {
+  const [agents, setAgents] = useState([]);
   const [selectedAgent, setSelectedAgent] = useState(null);
   const [selectedAgents, setSelectedAgents] = useState([]);
   const [inputValue, setInputValue] = useState("");
   const [output, setOutput] = useState(null);
   const [workflowOutput, setWorkflowOutput] = useState([]);
+
+  useEffect(() => {
+    const loadAgents = async () => {
+      try {
+        const res = await fetch('/registered-agents');
+        const data = await res.json();
+        if (Array.isArray(data)) setAgents(data.map(a => ({ id: a.agentId, name: a.displayName, description: a.description })));
+      } catch {
+        setAgents([]);
+      }
+    };
+    loadAgents();
+  }, []);
 
   const runDemo = async () => {
     if (!selectedAgent) return;
@@ -90,17 +83,7 @@ export default function AgentsGallery() {
                 className="form-checkbox h-4 w-4 text-blue-500"
               />
             </div>
-            <p className="text-gray-300 mb-2">{agent.description}</p>
-            <div className="flex flex-wrap gap-2 mb-4">
-              {agent.tags.map(tag => (
-                <span
-                  key={tag}
-                  className="text-xs px-2 py-1 bg-blue-500/30 rounded-full text-blue-100"
-                >
-                  {tag}
-                </span>
-              ))}
-            </div>
+            <p className="text-gray-300 mb-4">{agent.description}</p>
             <button
               onClick={() => {
                 setSelectedAgent(agent);

--- a/frontend/src/AgentConsoleView.jsx
+++ b/frontend/src/AgentConsoleView.jsx
@@ -2,12 +2,22 @@ import React, { useState, useEffect } from 'react';
 
 export default function AgentConsoleView() {
   const [logs, setLogs] = useState([]);
-  const [agents, setAgents] = useState([
-    { id: 'insights-agent', label: 'Insights', status: 'idle' },
-    { id: 'trends-agent', label: 'Trends', status: 'idle' },
-    { id: 'strategy-agent', label: 'Strategy', status: 'idle' },
-    { id: 'report-agent', label: 'Report', status: 'idle' },
-  ]);
+  const [agents, setAgents] = useState([]);
+
+  useEffect(() => {
+    const loadAgents = async () => {
+      try {
+        const res = await fetch('/registered-agents');
+        const data = await res.json();
+        if (Array.isArray(data)) {
+          setAgents(data.map(a => ({ id: a.agentId, label: a.displayName, status: 'idle' })));
+        }
+      } catch {
+        setAgents([]);
+      }
+    };
+    loadAgents();
+  }, []);
 
   useEffect(() => {
     const eventSource = new EventSource('/api/agent-logs');

--- a/frontend/src/LandingPage.jsx
+++ b/frontend/src/LandingPage.jsx
@@ -19,14 +19,35 @@ const LandingPage = () => {
   const [analysisResult, setAnalysisResult] = useState(null);
   const [emailSent, setEmailSent] = useState(false);
   const [logMessages, setLogMessages] = useState([]);
-  const agentList = ['insights-agent', 'trends-agent', 'anomaly-agent', 'forecast-agent'];
+  const [registeredAgents, setRegisteredAgents] = useState([]);
 
-  const analysisSteps = [
-    { icon: Globe, title: "Website Analysis", description: "Our AI scans your website architecture, content, and user flows" },
-    { icon: Brain, title: "Market Research", description: "Analyzing your industry, competitors, and market opportunities" },
-    { icon: TrendingUp, title: "GTM Strategy", description: "Identifying AI integration opportunities and growth potential" },
-    { icon: FileText, title: "Report Generation", description: "Creating your personalized AI transformation roadmap" }
+  useEffect(() => {
+    const fetchAgents = async () => {
+      try {
+        const res = await fetch('/registered-agents');
+        const data = await res.json();
+        if (Array.isArray(data)) setRegisteredAgents(data);
+      } catch {
+        setRegisteredAgents([]);
+      }
+    };
+    fetchAgents();
+  }, []);
+
+  const defaultSteps = [
+    { icon: Globe, title: 'Website Analysis', description: 'Our AI scans your website architecture, content, and user flows' },
+    { icon: Brain, title: 'Market Research', description: 'Analyzing your industry, competitors, and market opportunities' },
+    { icon: TrendingUp, title: 'GTM Strategy', description: 'Identifying AI integration opportunities and growth potential' },
+    { icon: FileText, title: 'Report Generation', description: 'Creating your personalized AI transformation roadmap' }
   ];
+
+  const analysisSteps = registeredAgents.length
+    ? registeredAgents.map(a => ({ icon: Globe, title: a.displayName, description: a.description }))
+    : defaultSteps;
+
+  const agentList = registeredAgents.length
+    ? registeredAgents.map(a => a.agentId)
+    : ['insights-agent', 'trends-agent', 'anomaly-agent', 'forecast-agent'];
 
   useEffect(() => {
     const saved = localStorage.getItem('sessionId');

--- a/functions/agentRegistry.js
+++ b/functions/agentRegistry.js
@@ -1,0 +1,32 @@
+const { writeDocument, readCollection } = require('./db');
+
+async function registerAgent(req, res) {
+  const { agentId, displayName, description, defaultSOP, renderComponent = '' } = req.body || {};
+  if (!agentId || !displayName || !description || !defaultSOP) {
+    return res.status(400).json({ error: 'agentId, displayName, description and defaultSOP are required' });
+  }
+  try {
+    await writeDocument('registered-agents', agentId, {
+      displayName,
+      description,
+      defaultSOP,
+      renderComponent
+    });
+    res.json({ success: true });
+  } catch (err) {
+    console.error('Failed to register agent:', err);
+    res.status(500).json({ error: 'Failed to register agent' });
+  }
+}
+
+async function listRegisteredAgents(_req, res) {
+  try {
+    const agents = await readCollection('registered-agents');
+    res.json(agents);
+  } catch (err) {
+    console.error('Failed to read agents:', err);
+    res.status(500).json({ error: 'Failed to read agents' });
+  }
+}
+
+module.exports = { registerAgent, listRegisteredAgents };

--- a/functions/index.js
+++ b/functions/index.js
@@ -10,6 +10,7 @@ const PDFDocument = require('pdfkit');
 const crypto = require('crypto');
 const loadAgents = require('./loadAgents');
 const agentMetadata = require('../agents/agent-metadata.json');
+const { registerAgent, listRegisteredAgents } = require('./agentRegistry');
 const {
   logAgentAction,
   readAuditLogs,
@@ -705,6 +706,10 @@ app.get('/resume/:sessionId', (req, res) => {
   const logs = getSessionLogs(sessionId);
   res.json({ status, logs });
 });
+
+// Plugin system - list and register agents
+app.get('/registered-agents', listRegisteredAgents);
+app.post('/register-agent', registerAgent);
 
 // LibreTranslate - available languages
 app.get('/locales', async (req, res) => {


### PR DESCRIPTION
## Summary
- implement `agentRegistry.js` with registerAgent and listRegisteredAgents
- expose `/register-agent` and `/registered-agents` API endpoints
- load registered agents on dashboard and console view
- show registered agents in LandingPage tracker and visualizer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855e433ab588323ad08e5bf6079e755