### PR TITLE
Add organization isolation

### DIFF
--- a/dashboard/src/App.jsx
+++ b/dashboard/src/App.jsx
@@ -1,5 +1,7 @@
 import { useState, useEffect } from 'react';
 import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom';
+import { collection, onSnapshot } from 'firebase/firestore';
+import { db } from './firebase';
 import AgentStatusTable from './components/AgentStatusTable';
 import MisalignmentProposalsPanel from './components/MisalignmentProposalsPanel';
 import ExecutionLogViewer from './components/ExecutionLogViewer';
@@ -9,16 +11,32 @@ export default function App() {
   const [dark, setDark] = useState(
     localStorage.getItem('theme') === 'dark'
   );
+  const [orgs, setOrgs] = useState([]);
+  const [orgId, setOrgId] = useState('');
 
   useEffect(() => {
     document.documentElement.classList.toggle('dark', dark);
     localStorage.setItem('theme', dark ? 'dark' : 'light');
   }, [dark]);
 
+  useEffect(() => {
+    const unsub = onSnapshot(collection(db, 'orgs'), snap => {
+      const list = snap.docs.map(d => ({ id: d.id, ...d.data() }));
+      setOrgs(list);
+      if (!orgId && list.length) setOrgId(list[0].id);
+    });
+    return unsub;
+  }, []);
+
   return (
     <Router basename="/dashboard">
       <div className="min-h-screen flex bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
         <aside className="w-48 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 p-4 flex flex-col">
+          <select value={orgId} onChange={e => setOrgId(e.target.value)} className="mb-4 p-1 rounded bg-gray-100 dark:bg-gray-700 text-sm">
+            {orgs.map(o => (
+              <option key={o.id} value={o.id}>{o.orgName || o.id}</option>
+            ))}
+          </select>
           <nav className="flex flex-col space-y-2 flex-1">
             <Link to="/" className="hover:underline">Status</Link>
             <Link to="/proposals" className="hover:underline">Proposals</Link>
@@ -30,7 +48,7 @@ export default function App() {
         </aside>
         <main className="flex-1 overflow-auto">
           <Routes>
-            <Route path="/" element={<AgentStatusTable />} />
+            <Route path="/" element={<AgentStatusTable orgId={orgId} />} />
             <Route path="/proposals" element={<MisalignmentProposalsPanel />} />
             <Route path="/logs" element={<ExecutionLogViewer />} />
           </Routes>

--- a/dashboard/src/components/AgentStatusTable.jsx
+++ b/dashboard/src/components/AgentStatusTable.jsx
@@ -9,16 +9,17 @@ const statusColors = {
   retired: 'bg-gray-200 text-gray-800',
 };
 
-export default function AgentStatusTable() {
+export default function AgentStatusTable({ orgId }) {
   const [agents, setAgents] = useState([]);
 
   useEffect(() => {
-    const unsub = onSnapshot(collection(db, 'agent-metadata'), snap => {
+    if (!orgId) return () => {};
+    const unsub = onSnapshot(collection(db, 'orgs', orgId, 'agents'), snap => {
       const data = snap.docs.map(d => ({ id: d.id, ...d.data() }));
       setAgents(data);
     });
     return unsub;
-  }, []);
+  }, [orgId]);
 
   return (
     <div className="p-4 overflow-auto">

--- a/functions/db.js
+++ b/functions/db.js
@@ -15,4 +15,17 @@ async function writeDocument(name, id, data) {
   await db.collection(name).doc(id).set(data, { merge: true });
 }
 
-module.exports = { db, appendToCollection, readCollection, writeDocument };
+async function isOrgMember(orgId, email) {
+  if (!orgId || !email) return false;
+  try {
+    const snap = await db.collection('orgs').doc(orgId).get();
+    if (!snap.exists) return false;
+    const data = snap.data() || {};
+    const members = Array.isArray(data.members) ? data.members : [];
+    return members.map(m => m.toLowerCase()).includes(email.toLowerCase());
+  } catch {
+    return false;
+  }
+}
+
+module.exports = { db, appendToCollection, readCollection, writeDocument, isOrgMember };


### PR DESCRIPTION
## Summary
- implement `isOrgMember` helper
- add organization-aware session logging and updates
- provide new endpoints to fetch org sessions and agents
- let dashboard users switch org context
- load agents for the selected organization

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855e43d09d88323bba2ebe209509241