### PR TITLE
Add billing tracking and Stripe endpoints

### DIFF
--- a/frontend/AgentBuilder.jsx
+++ b/frontend/AgentBuilder.jsx
@@ -127,6 +127,11 @@ export default function AgentBuilder() {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ agent: step.id, input: step.params })
         });
+        if (res.status === 403) {
+          alert("You've reached your monthly limit.");
+          setRunning(false);
+          return;
+        }
         const data = await res.json();
         if (data.error) {
           setLogs(prev => [...prev, `${step.id} error: ${data.error}`]);

--- a/frontend/AgentsGallery.jsx
+++ b/frontend/AgentsGallery.jsx
@@ -38,6 +38,10 @@ export default function AgentsGallery() {
         input: { text: inputValue || "Test input" }
       })
     });
+    if (res.status === 403) {
+      alert("You've reached your monthly limit.");
+      return;
+    }
     const result = await res.json();
     setOutput(result.response || result.error);
   };
@@ -63,6 +67,10 @@ export default function AgentsGallery() {
             input: { text: inputValue || "Test input" },
           }),
         });
+        if (res.status === 403) {
+          alert("You've reached your monthly limit.");
+          return;
+        }
         const result = await res.json();
         outputs.push({
           agent: agent.name,

--- a/frontend/client/BillingPanel.jsx
+++ b/frontend/client/BillingPanel.jsx
@@ -1,0 +1,55 @@
+import React, { useEffect, useState } from 'react';
+
+export default function BillingPanel() {
+  const [plan, setPlan] = useState('free');
+  const [usage, setUsage] = useState(0);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetch('/billing/info', {
+          headers: { Authorization: `Bearer ${localStorage.getItem('token') || ''}` }
+        });
+        const data = await res.json();
+        setPlan(data.plan || 'free');
+        setUsage(data.usage || 0);
+      } catch (err) {
+        console.error('Failed to load billing info', err);
+      }
+    };
+    load();
+  }, []);
+
+  const upgrade = async () => {
+    try {
+      const res = await fetch('/create-checkout-session', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${localStorage.getItem('token') || ''}`
+        },
+        body: JSON.stringify({})
+      });
+      const data = await res.json();
+      if (data.url) window.location.href = data.url;
+    } catch {
+      alert('Upgrade failed');
+    }
+  };
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold mb-4">Billing</h1>
+      <p className="mb-2">Current Plan: {plan === 'pro' ? 'Pro' : 'Free'}</p>
+      <p className="mb-4">Analyses this month: {usage}</p>
+      {plan !== 'pro' && (
+        <button
+          onClick={upgrade}
+          className="bg-blue-600 hover:bg-blue-700 text-white py-2 px-4 rounded"
+        >
+          Upgrade to Pro
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/client/ClientPortal.jsx
+++ b/frontend/client/ClientPortal.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import JSZip from 'jszip';
 import { saveAs } from 'file-saver';
+import BillingPanel from './BillingPanel.jsx';
 
 export default function ClientPortal({ reports = [] }) {
   const [sidebarOpen, setSidebarOpen] = useState(true);
@@ -124,12 +125,7 @@ export default function ClientPortal({ reports = [] }) {
           </div>
         )}
 
-        {activeTab === 'Billing' && (
-          <div>
-            <h1 className="text-2xl font-bold mb-4">Billing</h1>
-            <p>Billing information coming soon.</p>
-          </div>
-        )}
+        {activeTab === 'Billing' && <BillingPanel />}
       </div>
     </div>
   );

--- a/functions/index.js
+++ b/functions/index.js
@@ -17,6 +17,9 @@ const {
 } = require('./auditLogger');
 const runHealthChecks = require('./healthCheck');
 const { reportSOP } = require('./sopReporter');
+const { db } = require('./db');
+const { admin } = require('../firebase');
+const stripe = require('stripe')(process.env.STRIPE_KEY || '');
 
 // Load environment variables from .env if present
 dotenv.config();
@@ -89,6 +92,52 @@ function validateToken(token) {
   }
   loginTokens.delete(token);
   return data.email;
+}
+
+async function verifyUser(req) {
+  const header = req.headers.authorization || '';
+  const token = header.startsWith('Bearer ') ? header.slice(7) : null;
+  if (!token) return null;
+  try {
+    const decoded = await admin.auth().verifyIdToken(token);
+    return decoded.uid;
+  } catch {
+    return null;
+  }
+}
+
+async function getUserPlan(uid) {
+  try {
+    const doc = await db.collection('users').doc(uid).collection('subscription').doc('current').get();
+    return doc.exists ? doc.data().plan || 'free' : 'free';
+  } catch {
+    return 'free';
+  }
+}
+
+async function getUsageCount(uid) {
+  const start = new Date();
+  start.setDate(1);
+  start.setHours(0, 0, 0, 0);
+  const snap = await db
+    .collection('users')
+    .doc(uid)
+    .collection('usage')
+    .where('timestamp', '>=', start.toISOString())
+    .get();
+  return snap.size;
+}
+
+async function recordUsage(uid, sessionId, increments = {}) {
+  const ref = db.collection('users').doc(uid).collection('usage').doc(sessionId);
+  const update = { timestamp: new Date().toISOString() };
+  if (increments.stepCount)
+    update.stepCount = admin.firestore.FieldValue.increment(increments.stepCount);
+  if (increments.agentRuns)
+    update.agentRuns = admin.firestore.FieldValue.increment(increments.agentRuns);
+  if (increments.pdfGenerated)
+    update.pdfGenerated = admin.firestore.FieldValue.increment(increments.pdfGenerated);
+  await ref.set(update, { merge: true });
 }
 
 const LOG_DIR = path.join(__dirname, '..', 'logs');
@@ -470,6 +519,14 @@ app.post('/submit-agent', upload.single('code'), async (req, res) => {
 async function handleExecuteAgent(req, res) {
   const { agent: agentName, input = {}, sessionId, step, locale } = req.body || {};
 
+  const uid = await verifyUser(req);
+  if (!uid) return res.status(401).json({ error: 'Unauthorized' });
+  const plan = await getUserPlan(uid);
+  const usage = await getUsageCount(uid);
+  if (plan !== 'pro' && usage >= 3) {
+    return res.status(403).json({ error: 'limit' });
+  }
+
   if (!agentName) {
     appendLog({
       timestamp: new Date().toISOString(),
@@ -490,6 +547,7 @@ async function handleExecuteAgent(req, res) {
     }
     const response = { result: finalResult, allResults: results };
     res.json(response);
+    await recordUsage(uid, sessionId || Date.now().toString(), { stepCount: 1, agentRuns: 1 });
     runLifecycleCheck();
     return;
   } catch (err) {
@@ -506,6 +564,9 @@ async function handleSendReport(req, res) {
   if (!email) {
     return res.status(400).json({ error: 'Email is required' });
   }
+
+  const uid = await verifyUser(req);
+  if (!uid) return res.status(401).json({ error: 'Unauthorized' });
 
   try {
     const pdfBuffer = await new Promise((resolve, reject) => {
@@ -549,6 +610,7 @@ async function handleSendReport(req, res) {
     });
 
     res.json({ success: true });
+    await recordUsage(uid, sessionId || Date.now().toString(), { pdfGenerated: 1 });
     runLifecycleCheck();
   } catch (err) {
     console.error('Failed to send report email:', err);
@@ -557,6 +619,50 @@ async function handleSendReport(req, res) {
 }
 
 app.post('/send-report', handleSendReport);
+
+app.get('/billing/info', async (req, res) => {
+  const uid = await verifyUser(req);
+  if (!uid) return res.status(401).json({ error: 'Unauthorized' });
+  const plan = await getUserPlan(uid);
+  const usage = await getUsageCount(uid);
+  res.json({ plan, usage });
+});
+
+app.post('/create-checkout-session', async (req, res) => {
+  const uid = await verifyUser(req);
+  if (!uid) return res.status(401).json({ error: 'Unauthorized' });
+  try {
+    const session = await stripe.checkout.sessions.create({
+      mode: 'subscription',
+      line_items: [
+        { price: process.env.STRIPE_PRO_PRICE_ID, quantity: 1 }
+      ],
+      success_url: process.env.CHECKOUT_SUCCESS_URL || 'https://example.com?success=1',
+      cancel_url: process.env.CHECKOUT_CANCEL_URL || 'https://example.com?canceled=1',
+      metadata: { uid }
+    });
+    res.json({ url: session.url });
+  } catch (err) {
+    console.error('Stripe session error', err);
+    res.status(500).json({ error: 'stripe' });
+  }
+});
+
+app.post('/stripe/webhook', async (req, res) => {
+  const event = req.body;
+  if (event.type === 'invoice.paid') {
+    const uid = event.data.object.metadata?.uid;
+    if (uid) {
+      await db
+        .collection('users')
+        .doc(uid)
+        .collection('subscription')
+        .doc('current')
+        .set({ plan: 'pro', status: 'active' }, { merge: true });
+    }
+  }
+  res.json({ received: true });
+});
 
 // Send magic login link to client email
 app.post('/client/send-link', async (req, res) => {

--- a/functions/package.json
+++ b/functions/package.json
@@ -13,7 +13,8 @@
     "express": "^5.1.0",
     "firebase-admin": "^11.10.1",
     "firebase-functions": "^6.3.2",
-    "nodemailer": "^6.9.1"
+    "nodemailer": "^6.9.1",
+    "stripe": "^14.21.0"
   },
   "devDependencies": {
     "eslint": "^8.50.0"


### PR DESCRIPTION
## Summary
- integrate Stripe in functions
- add Firestore usage tracking helpers
- create `BillingPanel` UI component and link from client portal
- gate agent execution with free plan checks
- surface limit reached message in demos

## Testing
- `npm test`
- `(functions) npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855e449eb708323bc3793b571add4f3