### PR TITLE
Fix PDF report route and add org scoping

### DIFF
--- a/functions/agentRegistry.js
+++ b/functions/agentRegistry.js
@@ -1,12 +1,12 @@
 const { writeDocument, readCollection } = require('./db');
 
-async function registerAgent(req, res) {
+async function registerAgent(orgId, req, res) {
   const { agentId, displayName, description, defaultSOP, renderComponent = '' } = req.body || {};
   if (!agentId || !displayName || !description || !defaultSOP) {
     return res.status(400).json({ error: 'agentId, displayName, description and defaultSOP are required' });
   }
   try {
-    await writeDocument('registered-agents', agentId, {
+    await writeDocument(`orgs/${orgId}/agents`, agentId, {
       displayName,
       description,
       defaultSOP,
@@ -19,9 +19,9 @@ async function registerAgent(req, res) {
   }
 }
 
-async function listRegisteredAgents(_req, res) {
+async function listRegisteredAgents(orgId, _req, res) {
   try {
-    const agents = await readCollection('registered-agents');
+    const agents = await readCollection(`orgs/${orgId}/agents`);
     res.json(agents);
   } catch (err) {
     console.error('Failed to read agents:', err);

--- a/functions/db.js
+++ b/functions/db.js
@@ -2,17 +2,31 @@ const { admin } = require('../firebase');
 
 const db = admin.firestore();
 
-async function appendToCollection(name, data) {
-  await db.collection(name).add({ ...data, timestamp: new Date().toISOString() });
+function coll(path) {
+  const parts = path.split('/').filter(Boolean);
+  let ref = db;
+  while (parts.length) {
+    const col = parts.shift();
+    ref = ref.collection(col);
+    if (parts.length) {
+      const doc = parts.shift();
+      ref = ref.doc(doc);
+    }
+  }
+  return ref;
 }
 
-async function readCollection(name) {
-  const snap = await db.collection(name).orderBy('timestamp').get();
+async function appendToCollection(path, data) {
+  await coll(path).add({ ...data, timestamp: new Date().toISOString() });
+}
+
+async function readCollection(path) {
+  const snap = await coll(path).orderBy('timestamp').get();
   return snap.docs.map(d => d.data());
 }
 
-async function writeDocument(name, id, data) {
-  await db.collection(name).doc(id).set(data, { merge: true });
+async function writeDocument(path, id, data) {
+  await coll(path).doc(id).set(data, { merge: true });
 }
 
 module.exports = { db, appendToCollection, readCollection, writeDocument };


### PR DESCRIPTION
## Summary
- add Firestore path helper and update agent registry
- add organization membership helpers
- enforce org checks on agent and session routes
- implement `/generate-report/:sessionId` PDF endpoint

## Testing
- `npm --prefix functions run lint`
- `npm --prefix functions test`

------
https://chatgpt.com/codex/tasks/task_e_6855e7198ed08323a9f31bd1e5cdaa10