### PR TITLE
Implement org-aware dashboard shell

### DIFF
--- a/dashboard/src/App.jsx
+++ b/dashboard/src/App.jsx
@@ -1,23 +1,46 @@
 import { useState, useEffect } from 'react';
 import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom';
+import { OrgProvider, useOrg } from './OrgContext';
 import AgentStatusTable from './components/AgentStatusTable';
 import MisalignmentProposalsPanel from './components/MisalignmentProposalsPanel';
 import ExecutionLogViewer from './components/ExecutionLogViewer';
 import AgentHealthDashboard from './components/AgentHealthDashboard';
 import './index.css';
 
-export default function App() {
+function Shell() {
   const [dark, setDark] = useState(
     localStorage.getItem('theme') === 'dark'
   );
+  const { orgId, setOrgId, orgs, loading } = useOrg();
 
   useEffect(() => {
     document.documentElement.classList.toggle('dark', dark);
     localStorage.setItem('theme', dark ? 'dark' : 'light');
   }, [dark]);
 
+  if (loading) {
+    return <div className="p-4 text-center text-white">Loading...</div>;
+  }
+
+  if (!orgId) {
+    return (
+      <div className="p-4 text-center text-white">No organizations available.</div>
+    );
+  }
+
   return (
     <Router basename="/dashboard">
+      <select
+        value={orgId}
+        onChange={e => setOrgId(e.target.value)}
+        className="fixed top-4 right-6 z-50 bg-gray-900 text-white rounded shadow-md px-2 py-1"
+      >
+        {orgs.map(o => (
+          <option key={o.id} value={o.id}>
+            {o.name || o.id}
+          </option>
+        ))}
+      </select>
       <div className="min-h-screen flex bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
         <aside className="w-48 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 p-4 flex flex-col">
           <nav className="flex flex-col space-y-2 flex-1">
@@ -42,3 +65,12 @@ export default function App() {
     </Router>
   );
 }
+
+export default function App() {
+  return (
+    <OrgProvider>
+      <Shell />
+    </OrgProvider>
+  );
+}
+

--- a/dashboard/src/OrgContext.jsx
+++ b/dashboard/src/OrgContext.jsx
@@ -1,0 +1,39 @@
+import { createContext, useContext, useEffect, useState } from 'react';
+import { auth, db } from './firebase';
+import { onAuthStateChanged } from 'firebase/auth';
+import { collection, getDocs } from 'firebase/firestore';
+
+const OrgContext = createContext({ orgId: null, orgs: [], setOrgId: () => {} });
+
+export function OrgProvider({ children }) {
+  const [orgId, setOrgId] = useState(null);
+  const [orgs, setOrgs] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const unsub = onAuthStateChanged(auth, async user => {
+      if (user) {
+        try {
+          const snap = await getDocs(collection(db, 'users', user.uid, 'orgs'));
+          const list = snap.docs.map(d => ({ id: d.id, ...d.data() }));
+          setOrgs(list);
+          if (list.length) setOrgId(list[0].id);
+        } catch {
+          setOrgs([]);
+        }
+      } else {
+        setOrgs([]);
+      }
+      setLoading(false);
+    });
+    return unsub;
+  }, []);
+
+  return (
+    <OrgContext.Provider value={{ orgId, setOrgId, orgs, loading }}>
+      {children}
+    </OrgContext.Provider>
+  );
+}
+
+export const useOrg = () => useContext(OrgContext);

--- a/dashboard/src/components/AgentStatusTable.jsx
+++ b/dashboard/src/components/AgentStatusTable.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { collection, onSnapshot } from 'firebase/firestore';
 import { db } from '../firebase';
+import { useOrg } from '../OrgContext';
 
 const statusColors = {
   development: 'bg-blue-100 text-blue-800',
@@ -11,14 +12,19 @@ const statusColors = {
 
 export default function AgentStatusTable() {
   const [agents, setAgents] = useState([]);
+  const { orgId } = useOrg();
 
   useEffect(() => {
-    const unsub = onSnapshot(collection(db, 'agent-metadata'), snap => {
-      const data = snap.docs.map(d => ({ id: d.id, ...d.data() }));
-      setAgents(data);
-    });
+    if (!orgId) return;
+    const unsub = onSnapshot(
+      collection(db, 'orgs', orgId, 'agent-metadata'),
+      snap => {
+        const data = snap.docs.map(d => ({ id: d.id, ...d.data() }));
+        setAgents(data);
+      }
+    );
     return unsub;
-  }, []);
+  }, [orgId]);
 
   return (
     <div className="p-4 overflow-auto">

--- a/dashboard/src/components/ExecutionLogViewer.jsx
+++ b/dashboard/src/components/ExecutionLogViewer.jsx
@@ -1,19 +1,22 @@
 import { useEffect, useState } from 'react';
 import { collection, onSnapshot, query, orderBy } from 'firebase/firestore';
 import { db } from '../firebase';
+import { useOrg } from '../OrgContext';
 
 export default function ExecutionLogViewer() {
   const [logs, setLogs] = useState([]);
   const [filter, setFilter] = useState('');
+  const { orgId } = useOrg();
 
   useEffect(() => {
-    const q = query(collection(db, 'logs'), orderBy('timestamp', 'desc'));
+    if (!orgId) return;
+    const q = query(collection(db, 'orgs', orgId, 'logs'), orderBy('timestamp', 'desc'));
     const unsub = onSnapshot(q, snap => {
       const data = snap.docs.map(d => ({ id: d.id, ...d.data() }));
       setLogs(data);
     });
     return unsub;
-  }, []);
+  }, [orgId]);
 
   const filtered = filter
     ? logs.filter(l => (l.agent || '').includes(filter))
@@ -46,3 +49,4 @@ export default function ExecutionLogViewer() {
     </div>
   );
 }
+

--- a/dashboard/src/components/MisalignmentProposalsPanel.jsx
+++ b/dashboard/src/components/MisalignmentProposalsPanel.jsx
@@ -1,18 +1,21 @@
 import { useEffect, useState } from 'react';
 import { doc, onSnapshot } from 'firebase/firestore';
 import { db } from '../firebase';
+import { useOrg } from '../OrgContext';
 
 export default function MisalignmentProposalsPanel() {
   const [proposals, setProposals] = useState([]);
+  const { orgId } = useOrg();
 
   useEffect(() => {
-    const unsub = onSnapshot(doc(db, 'guardian', 'proposals'), snap => {
+    if (!orgId) return;
+    const unsub = onSnapshot(doc(db, 'orgs', orgId, 'guardian', 'proposals'), snap => {
       const data = snap.data() || {};
       const list = data.proposals || data.list || [];
       setProposals(Array.isArray(list) ? list : Object.values(list));
     });
     return unsub;
-  }, []);
+  }, [orgId]);
 
   return (
     <div className="p-4">
@@ -28,3 +31,4 @@ export default function MisalignmentProposalsPanel() {
     </div>
   );
 }
+

--- a/dashboard/src/firebase.js
+++ b/dashboard/src/firebase.js
@@ -1,4 +1,5 @@
 import { initializeApp } from 'firebase/app';
+import { getAuth } from 'firebase/auth';
 import { getFirestore } from 'firebase/firestore';
 
 const firebaseConfig = {
@@ -8,4 +9,6 @@ const firebaseConfig = {
 };
 
 const app = initializeApp(firebaseConfig);
+export const auth = getAuth(app);
 export const db = getFirestore(app);
+


### PR DESCRIPTION
## Summary
- create `OrgContext` for organization selection
- expose Firebase auth object
- add org switching dropdown and loading/fallback states
- update dashboard components to query under `/orgs/{orgId}`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855e7287b588323b6629b464f7b6ef9