### PR TITLE
Add DevAgentLogSimulator component

### DIFF
--- a/frontend/src/DevAgentLogSimulator.jsx
+++ b/frontend/src/DevAgentLogSimulator.jsx
@@ -1,0 +1,75 @@
+import React, { useState, useEffect } from 'react';
+import { collection, addDoc, onSnapshot } from 'firebase/firestore';
+import { db } from './firebase';
+
+export default function DevAgentLogSimulator() {
+  if (process.env.NODE_ENV === 'production') return null;
+
+  const [orgId, setOrgId] = useState('');
+  const [sessionId, setSessionId] = useState('');
+  const [agentId, setAgentId] = useState('');
+  const [message, setMessage] = useState('');
+  const [agents, setAgents] = useState([]);
+
+  useEffect(() => {
+    const savedSession = localStorage.getItem('sessionId');
+    if (savedSession) setSessionId(savedSession);
+  }, []);
+
+  useEffect(() => {
+    const unsub = onSnapshot(collection(db, 'agent-metadata'), snap => {
+      setAgents(snap.docs.map(d => d.id));
+    });
+    return unsub;
+  }, []);
+
+  const pushLog = async () => {
+    if (!orgId || !sessionId || !agentId || !message) return;
+    await addDoc(collection(db, 'orgs', orgId, 'logs', sessionId), {
+      agent: agentId,
+      output: message,
+      timestamp: new Date().toISOString(),
+    });
+    setMessage('');
+  };
+
+  return (
+    <div className="space-y-2">
+      <input
+        type="text"
+        placeholder="Org ID"
+        value={orgId}
+        onChange={e => setOrgId(e.target.value)}
+        className="w-full p-1 rounded text-black"
+      />
+      <input
+        type="text"
+        placeholder="Session ID"
+        value={sessionId}
+        onChange={e => setSessionId(e.target.value)}
+        className="w-full p-1 rounded text-black"
+      />
+      <select
+        value={agentId}
+        onChange={e => setAgentId(e.target.value)}
+        className="w-full p-1 rounded text-black"
+      >
+        <option value="">Select agent</option>
+        {agents.map(a => (
+          <option key={a} value={a}>
+            {a}
+          </option>
+        ))}
+      </select>
+      <textarea
+        value={message}
+        onChange={e => setMessage(e.target.value)}
+        rows={3}
+        className="w-full p-1 rounded text-black"
+      />
+      <button onClick={pushLog} className="bg-blue-500 text-white px-2 py-1 rounded">
+        Push Log
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/DevToolsPanel.jsx
+++ b/frontend/src/DevToolsPanel.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import DevAgentLogSimulator from './DevAgentLogSimulator.jsx';
 import { Tab, Disclosure } from '@headlessui/react';
 import { Settings, X } from 'lucide-react';
 import {
@@ -103,7 +104,11 @@ export default function DevToolsPanel() {
           </div>
           <Tab.Group as="div" className="flex-1 flex flex-col">
             <Tab.List className="flex space-x-1 bg-gray-200 dark:bg-gray-700 p-1">
-              {['Firestore', 'Sim Logs', 'SOP', 'Control'].map(tab => (
+              {(
+                process.env.NODE_ENV !== 'production'
+                  ? ['Firestore', 'Sim Logs', 'SOP', 'Control', 'Log Simulator']
+                  : ['Firestore', 'Sim Logs', 'SOP', 'Control']
+              ).map(tab => (
                 <Tab
                   key={tab}
                   className={({ selected }) =>
@@ -181,6 +186,11 @@ export default function DevToolsPanel() {
                   {paused ? 'Resume' : 'Pause'}
                 </button>
               </Tab.Panel>
+              {process.env.NODE_ENV !== 'production' && (
+                <Tab.Panel className="space-y-2">
+                  <DevAgentLogSimulator />
+                </Tab.Panel>
+              )}
             </Tab.Panels>
           </Tab.Group>
         </div>


### PR DESCRIPTION
## Summary
- add `DevAgentLogSimulator` component to allow pushing logs to Firestore
- extend DevToolsPanel with a new dev-only tab for the simulator

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855ee132e888323b62e61936e634b33