### PR TITLE
Add process guardian agent

### DIFF
--- a/PROCESS_LOG.md
+++ b/PROCESS_LOG.md
@@ -1,0 +1,5 @@
+# Process Log
+
+
+## [2025-06-20]
+✅ Infra — Merge pull request #135 from Csp-Ai/codex/rebase-branch-and-retry-failed-patch

--- a/agents/agent-metadata.json
+++ b/agents/agent-metadata.json
@@ -20,7 +20,11 @@
     "createdBy": "Csp-Ai",
     "lastUpdated": "2025-06-19",
     "critical": true,
-    "locales": ["en", "es", "fr"],
+    "locales": [
+      "en",
+      "es",
+      "fr"
+    ],
     "lifecycle": "incubation",
     "status": "planned",
     "locale": "en-US",
@@ -46,7 +50,11 @@
     "createdBy": "Csp-Ai",
     "lastUpdated": "2025-06-19",
     "critical": true,
-    "locales": ["en", "es", "fr"],
+    "locales": [
+      "en",
+      "es",
+      "fr"
+    ],
     "lifecycle": "incubation",
     "status": "planned",
     "locale": "en-US",
@@ -70,7 +78,11 @@
     "createdBy": "Csp-Ai",
     "lastUpdated": "2025-06-19",
     "critical": true,
-    "locales": ["en", "es", "fr"],
+    "locales": [
+      "en",
+      "es",
+      "fr"
+    ],
     "lifecycle": "production",
     "locale": "en-US",
     "misaligned": false
@@ -94,7 +106,11 @@
     "createdBy": "Csp-Ai",
     "lastUpdated": "2025-06-19",
     "critical": true,
-    "locales": ["en", "es", "fr"],
+    "locales": [
+      "en",
+      "es",
+      "fr"
+    ],
     "lifecycle": "incubation",
     "locale": "en-US",
     "misaligned": false
@@ -114,7 +130,11 @@
     "createdBy": "Csp-Ai",
     "lastUpdated": "2025-06-19",
     "critical": true,
-    "locales": ["en", "es", "fr"],
+    "locales": [
+      "en",
+      "es",
+      "fr"
+    ],
     "lifecycle": "production",
     "locale": "en-US",
     "misaligned": false
@@ -135,7 +155,11 @@
     "createdBy": "Csp-Ai",
     "lastUpdated": "2025-06-19",
     "critical": true,
-    "locales": ["en", "es", "fr"],
+    "locales": [
+      "en",
+      "es",
+      "fr"
+    ],
     "lifecycle": "production",
     "locale": "en-US",
     "misaligned": false
@@ -155,7 +179,11 @@
     "createdBy": "Csp-Ai",
     "lastUpdated": "2025-06-19",
     "critical": true,
-    "locales": ["en", "es", "fr"],
+    "locales": [
+      "en",
+      "es",
+      "fr"
+    ],
     "lifecycle": "production",
     "locale": "en-US",
     "misaligned": false
@@ -179,10 +207,32 @@
     "createdBy": "Csp-Ai",
     "lastUpdated": "2025-06-19",
     "critical": true,
-    "locales": ["en"],
+    "locales": [
+      "en"
+    ],
+    "lifecycle": "incubation",
+    "locale": "en-US",
+    "misaligned": false
+  },
+  "process-guardian-agent": {
+    "name": "Process Guardian Agent",
+    "description": "Logs commits with category tags for roadmap tracking.",
+    "inputs": {},
+    "outputs": {
+      "categories": "array",
+      "message": "string"
+    },
+    "category": "Governance",
+    "enabled": true,
+    "version": "1.0.0",
+    "createdBy": "Csp-Ai",
+    "lastUpdated": "2025-06-19",
+    "critical": false,
+    "locales": [
+      "en"
+    ],
     "lifecycle": "incubation",
     "locale": "en-US",
     "misaligned": false
   }
 }
-

--- a/agents/process-guardian-agent.js
+++ b/agents/process-guardian-agent.js
@@ -1,0 +1,57 @@
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+function latestCommit() {
+  const message = execSync('git -c color.ui=never log -1 --pretty=%s').toString().trim();
+  const files = execSync('git -c color.ui=never show --name-only --pretty="" -1').toString().trim().split('\n').filter(Boolean);
+  return { message, files };
+}
+
+function categorize(files, message) {
+  const cats = new Set();
+  const msg = message.toLowerCase();
+  if (files.some(f => /frontend|public|dashboard/.test(f))) cats.add('Frontend');
+  if (files.some(f => /agents|functions|scripts/.test(f))) cats.add('Agent Logic');
+  if (files.some(f => /Dockerfile|package.json|\.github|deploy|firebase/.test(f))) cats.add('Infra');
+  if (files.some(f => /\.md$|docs\//.test(f)) || /docs?|documentation/.test(msg)) cats.add('Docs');
+  if (files.some(f => /ROADMAP.md|VISION.md|TECH_ARCH.md/i.test(f)) || /vision|roadmap|tech arch/.test(msg)) cats.add('Vision');
+  if (!cats.size) cats.add('Infra');
+  return Array.from(cats);
+}
+
+function updateLog(categories, message, files) {
+  const logPath = path.join(__dirname, '..', 'PROCESS_LOG.md');
+  const date = new Date().toISOString().slice(0, 10);
+  const strategic = files.some(f => /ROADMAP.md|VISION.md|TECH_ARCH.md/i.test(f)) ? ' \ud83d\udccc Strategic Update' : '';
+  const entryLines = categories.map(c => `\u2705 ${c} \u2014 ${message}${strategic}`);
+  let text = '';
+  if (fs.existsSync(logPath)) text = fs.readFileSync(logPath, 'utf8');
+  if (!text.startsWith('# Process Log')) {
+    text = `# Process Log\n\n${text}`.trim() + '\n';
+  }
+  const lines = text.split('\n');
+  let idx = lines.findIndex(l => l.startsWith(`## [${date}]`));
+  if (idx === -1) {
+    lines.push('', `## [${date}]`);
+    idx = lines.length - 1;
+  }
+  lines.splice(idx + 1, 0, ...entryLines);
+  fs.writeFileSync(logPath, lines.join('\n') + '\n');
+}
+
+module.exports = {
+  run: async () => {
+    const { message, files } = latestCommit();
+    const categories = categorize(files, message);
+    updateLog(categories, message, files);
+    return { categories, message };
+  }
+};
+
+if (require.main === module) {
+  module.exports.run().catch(err => {
+    console.error('process-guardian-agent failed:', err);
+    process.exit(1);
+  });
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "setup:live": "node scripts/setup-and-deploy-live.js",
     "postdeploy:cloudrun": "node scripts/cloudrun-postdeploy.js",
     "postdeploy:summary": "node scripts/postDeploySummary.js",
-    "postdeploy:all": "node scripts/postDeploySummary.js"
+    "postdeploy:all": "node scripts/postDeploySummary.js",
+    "process-log": "node agents/process-guardian-agent.js"
   },
   "keywords": [
     "AI",


### PR DESCRIPTION
## Summary
- add `process-guardian-agent.js` to categorize commits and log progress
- update agent metadata with new meta-agent info
- provide npm script `process-log`
- create `PROCESS_LOG.md` for daily updates

## Testing
- `npm test`
- `npm run process-log`


------
https://chatgpt.com/codex/tasks/task_e_6855eef48c508323829d8f18f368c2cf