### PR TITLE
Add Agent Systems Gallery and simulation endpoint

### DIFF
--- a/dashboard/src/App.jsx
+++ b/dashboard/src/App.jsx
@@ -5,6 +5,7 @@ import AgentStatusTable from './components/AgentStatusTable';
 import MisalignmentProposalsPanel from './components/MisalignmentProposalsPanel';
 import ExecutionLogViewer from './components/ExecutionLogViewer';
 import AgentHealthDashboard from './components/AgentHealthDashboard';
+import AgentGallery from './pages/AgentGallery';
 import './index.css';
 
 function Shell() {
@@ -48,6 +49,7 @@ function Shell() {
             <Link to="/health" className="hover:underline">Health</Link>
             <Link to="/proposals" className="hover:underline">Proposals</Link>
             <Link to="/logs" className="hover:underline">Logs</Link>
+            <Link to="/agents" className="hover:underline">Agents</Link>
           </nav>
           <button onClick={() => setDark(!dark)} className="text-sm mt-4">
             Toggle {dark ? 'Light' : 'Dark'}
@@ -59,6 +61,7 @@ function Shell() {
             <Route path="/health" element={<AgentHealthDashboard />} />
             <Route path="/proposals" element={<MisalignmentProposalsPanel />} />
             <Route path="/logs" element={<ExecutionLogViewer />} />
+            <Route path="/agents" element={<AgentGallery />} />
           </Routes>
         </main>
       </div>

--- a/dashboard/src/components/AgentDetailsModal.jsx
+++ b/dashboard/src/components/AgentDetailsModal.jsx
@@ -1,0 +1,67 @@
+import { useState } from 'react';
+
+export default function AgentDetailsModal({ agent, onClose, orgId }) {
+  const [input, setInput] = useState('');
+  const [response, setResponse] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  const send = async () => {
+    setLoading(true);
+    setResponse(null);
+    try {
+      const res = await fetch('/simulate-agent', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ agentId: agent.id, orgId, input })
+      });
+      const data = await res.json();
+      setResponse(data.agentResponse || data.error);
+    } catch (err) {
+      setResponse(err.message);
+    }
+    setLoading(false);
+  };
+
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black/50 z-50">
+      <div className="bg-white dark:bg-gray-800 rounded-lg w-96 max-w-full p-6">
+        <h3 className="text-lg font-semibold mb-2">{agent.name || agent.id}</h3>
+        <p className="text-sm mb-2">{agent.description}</p>
+        <ul className="list-disc list-inside text-sm mb-4">
+          <li>Version: {agent.version}</li>
+          <li>Last SOP Update: {agent.lastUpdated}</li>
+          {agent.dependsOn && agent.dependsOn.length > 0 && (
+            <li>Dependencies: {agent.dependsOn.join(', ')}</li>
+          )}
+          <li>Owner: {agent.createdBy}</li>
+        </ul>
+        <input
+          className="w-full border rounded p-2 mb-3 text-sm dark:bg-gray-700"
+          value={input}
+          onChange={e => setInput(e.target.value)}
+          placeholder="Send a command"
+        />
+        <div className="flex gap-2 mb-2">
+          <button
+            onClick={send}
+            disabled={loading}
+            className="flex-1 bg-green-500 hover:bg-green-600 text-white text-sm px-2 py-1 rounded"
+          >
+            {loading ? 'Sending...' : 'Send'}
+          </button>
+          <button
+            onClick={onClose}
+            className="flex-1 bg-gray-300 hover:bg-gray-400 text-sm rounded dark:bg-gray-600 dark:hover:bg-gray-500"
+          >
+            Close
+          </button>
+        </div>
+        {response && (
+          <div className="mt-2 text-sm bg-gray-100 dark:bg-gray-700 p-2 rounded">
+            {response}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/pages/AgentGallery.jsx
+++ b/dashboard/src/pages/AgentGallery.jsx
@@ -1,0 +1,70 @@
+import { useEffect, useState } from 'react';
+import AgentDetailsModal from '../components/AgentDetailsModal';
+import { useOrg } from '../OrgContext';
+
+export default function AgentGallery() {
+  const [agents, setAgents] = useState([]);
+  const [active, setActive] = useState(null);
+  const { orgId } = useOrg();
+
+  useEffect(() => {
+    fetch('/agents/agent-metadata.json')
+      .then(res => res.json())
+      .then(data => {
+        const list = Object.entries(data).map(([id, meta]) => ({ id, ...meta }));
+        setAgents(list);
+      })
+      .catch(() => setAgents([]));
+  }, []);
+
+  return (
+    <div className="p-4">
+      <h2 className="text-xl font-semibold mb-4">Agent Systems Gallery</h2>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {agents.map(a => (
+          <div
+            key={a.id}
+            className="bg-white dark:bg-gray-800 rounded-lg shadow hover:shadow-lg transform hover:-translate-y-1 transition"
+          >
+            <div className="p-4 flex items-start">
+              <div className="w-10 h-10 rounded-full bg-gray-200 dark:bg-gray-700 flex items-center justify-center mr-3">
+                <span className="text-xl">🤖</span>
+              </div>
+              <div className="flex-1">
+                <h3 className="font-medium">{a.name || a.id}</h3>
+                <p className="text-sm text-gray-600 dark:text-gray-400">
+                  {a.description}
+                </p>
+              </div>
+              <span
+                className={`ml-2 w-3 h-3 rounded-full ${a.enabled ? 'bg-green-500' : 'bg-yellow-500'}`}
+              />
+            </div>
+            <ul className="px-4 pb-2 list-disc list-inside text-sm text-gray-600 dark:text-gray-300">
+              <li>Category: {a.category}</li>
+              <li>Lifecycle: {a.lifecycle}</li>
+              <li>Version: {a.version}</li>
+            </ul>
+            <div className="px-4 pb-4 flex gap-2">
+              <button
+                onClick={() => setActive(a)}
+                className="flex-1 bg-blue-500 hover:bg-blue-600 text-white text-sm px-2 py-1 rounded"
+              >
+                Learn More
+              </button>
+              <button
+                onClick={() => setActive(a)}
+                className="flex-1 bg-green-500 hover:bg-green-600 text-white text-sm px-2 py-1 rounded"
+              >
+                Test Agent
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+      {active && (
+        <AgentDetailsModal agent={active} orgId={orgId} onClose={() => setActive(null)} />
+      )}
+    </div>
+  );
+}

--- a/functions/simulateAgent.js
+++ b/functions/simulateAgent.js
@@ -1,0 +1,26 @@
+const { functions } = require('../firebase');
+const { db } = require('./db');
+
+async function handler(req, res) {
+  if (req.method !== 'POST') return res.status(405).end();
+  const { agentId, orgId, input } = req.body || {};
+  if (!agentId) return res.status(400).json({ error: 'agentId required' });
+
+  const response = { agentResponse: `\uD83E\uDD16 ${agentId} received your message!` };
+
+  try {
+    if (orgId) {
+      await db
+        .collection('orgs')
+        .doc(orgId)
+        .collection('simulations')
+        .add({ agentId, input, userAgent: req.get('user-agent') || '', timestamp: new Date().toISOString() });
+    }
+  } catch (err) {
+    console.error('Failed to log simulation:', err.message);
+  }
+
+  res.json(response);
+}
+
+exports.simulateAgent = functions.https.onRequest(handler);


### PR DESCRIPTION
## Summary
- add AgentGallery page to dashboard and modal for agent details
- integrate new `/agents` route and navigation link
- create AgentDetailsModal for testing agents
- implement new Cloud Function `simulateAgent` for dummy agent responses

## Testing
- `npm test`
- `npm --prefix functions test`


------
https://chatgpt.com/codex/tasks/task_e_6855f12ad1208323958e413053d268a2