### PR TITLE
Add departmental agent infrastructure and knowledge utilities

### DIFF
--- a/agents/agent-catalog.json
+++ b/agents/agent-catalog.json
@@ -1,0 +1,9 @@
+{
+  "sales": ["board-agent"],
+  "marketing": ["insights-agent", "website-scanner-agent"],
+  "operations": ["guardian-agent", "process-guardian-agent", "vision-guard-agent", "report-generator-agent"],
+  "finance": ["data-analyst-agent"],
+  "hr": ["mentor-agent"],
+  "it": ["codex-qa-agent"],
+  "support": []
+}

--- a/dashboard/src/App.jsx
+++ b/dashboard/src/App.jsx
@@ -6,6 +6,7 @@ import MisalignmentProposalsPanel from './components/MisalignmentProposalsPanel'
 import ExecutionLogViewer from './components/ExecutionLogViewer';
 import AgentHealthDashboard from './components/AgentHealthDashboard';
 import AgentGallery from './pages/AgentGallery';
+import DepartmentRouter from './pages/DepartmentRouter';
 import './index.css';
 
 function Shell() {
@@ -50,6 +51,7 @@ function Shell() {
             <Link to="/proposals" className="hover:underline">Proposals</Link>
             <Link to="/logs" className="hover:underline">Logs</Link>
             <Link to="/agents" className="hover:underline">Agents</Link>
+            <Link to="/departments/sales" className="hover:underline">Departments</Link>
           </nav>
           <button onClick={() => setDark(!dark)} className="text-sm mt-4">
             Toggle {dark ? 'Light' : 'Dark'}
@@ -62,6 +64,7 @@ function Shell() {
             <Route path="/proposals" element={<MisalignmentProposalsPanel />} />
             <Route path="/logs" element={<ExecutionLogViewer />} />
             <Route path="/agents" element={<AgentGallery />} />
+            <Route path="/departments/:dept" element={<DepartmentRouter />} />
           </Routes>
         </main>
       </div>

--- a/dashboard/src/components/AgentDepartmentSwitcher.jsx
+++ b/dashboard/src/components/AgentDepartmentSwitcher.jsx
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+
+export default function AgentDepartmentSwitcher({ value, onChange }) {
+  const [departments, setDepartments] = useState([]);
+
+  useEffect(() => {
+    fetch('/agents/agent-catalog.json')
+      .then(res => res.json())
+      .then(data => setDepartments(Object.keys(data)))
+      .catch(() => setDepartments([]));
+  }, []);
+
+  return (
+    <select
+      value={value}
+      onChange={e => onChange(e.target.value)}
+      className="border px-2 py-1 rounded bg-white dark:bg-gray-800">
+      {departments.map(dep => (
+        <option key={dep} value={dep}>
+          {dep.charAt(0).toUpperCase() + dep.slice(1)}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/dashboard/src/components/DepartmentDashboard.jsx
+++ b/dashboard/src/components/DepartmentDashboard.jsx
@@ -1,0 +1,89 @@
+import { useEffect, useState } from 'react';
+import { collection, query, where, orderBy, onSnapshot } from 'firebase/firestore';
+import AgentDetailsModal from './AgentDetailsModal';
+import { db } from '../firebase';
+import { useOrg } from '../OrgContext';
+
+export default function DepartmentDashboard({ department }) {
+  const [agents, setAgents] = useState([]);
+  const [logs, setLogs] = useState([]);
+  const [active, setActive] = useState(null);
+  const { orgId } = useOrg();
+
+  useEffect(() => {
+    Promise.all([
+      fetch('/agents/agent-catalog.json').then(r => r.json()),
+      fetch('/agents/agent-metadata.json').then(r => r.json()),
+    ])
+      .then(([catalog, meta]) => {
+        const ids = catalog[department] || [];
+        const list = ids.map(id => ({ id, ...meta[id] })).filter(a => a);
+        setAgents(list);
+      })
+      .catch(() => setAgents([]));
+  }, [department]);
+
+  useEffect(() => {
+    if (!orgId || !agents.length) { setLogs([]); return; }
+    const ids = agents.map(a => a.id);
+    const chunks = [];
+    for (let i = 0; i < ids.length; i += 10) {
+      const q = query(
+        collection(db, 'orgs', orgId, 'logs'),
+        where('agent', 'in', ids.slice(i, i + 10)),
+        orderBy('timestamp', 'desc')
+      );
+      chunks.push(q);
+    }
+    const unsubs = chunks.map(q => onSnapshot(q, snap => {
+      setLogs(prev => {
+        const filtered = prev.filter(l => !ids.includes(l.agent));
+        const arr = snap.docs.map(d => ({ id: d.id, ...d.data() }));
+        return [...filtered, ...arr].sort((a,b) => new Date(b.timestamp) - new Date(a.timestamp));
+      });
+    }));
+    return () => unsubs.forEach(u => u());
+  }, [orgId, agents]);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-xl font-semibold capitalize mb-2">{department} Department</h2>
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {agents.map(a => (
+            <div key={a.id} className="bg-white dark:bg-gray-800 rounded-lg shadow">
+              <div className="p-3">
+                <h4 className="font-semibold">{a.name || a.id}</h4>
+                <p className="text-sm text-gray-600 dark:text-gray-400">{a.description}</p>
+              </div>
+              <div className="p-3 flex gap-2">
+                <button onClick={() => setActive(a)} className="flex-1 bg-blue-500 hover:bg-blue-600 text-white text-sm px-2 py-1 rounded">Run</button>
+                <button onClick={() => setActive(a)} className="flex-1 bg-gray-300 hover:bg-gray-400 text-sm rounded dark:bg-gray-600 dark:hover:bg-gray-500">Logs</button>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+      <div>
+        <h3 className="font-medium mb-2">Team Collaboration</h3>
+        <div className="bg-white dark:bg-gray-800 p-3 rounded text-sm">
+          {agents.map(a => a.name || a.id).join(' \u2192 ')}
+        </div>
+      </div>
+      <div>
+        <h3 className="font-medium mb-2">Recent Activity</h3>
+        <ul className="space-y-2 max-h-[40vh] overflow-auto">
+          {logs.map(log => (
+            <li key={log.id} className="border rounded p-2 text-sm dark:border-gray-700">
+              <div className="text-gray-500">
+                {new Date(log.timestamp).toLocaleString()} - {log.agent}
+              </div>
+              <div className="whitespace-pre-wrap">{log.outputSnippet || log.output || ''}</div>
+            </li>
+          ))}
+        </ul>
+      </div>
+      {active && <AgentDetailsModal agent={active} onClose={() => setActive(null)} orgId={orgId} />}
+    </div>
+  );
+}

--- a/dashboard/src/pages/DepartmentRouter.jsx
+++ b/dashboard/src/pages/DepartmentRouter.jsx
@@ -1,0 +1,15 @@
+import { useParams, useNavigate } from 'react-router-dom';
+import AgentDepartmentSwitcher from '../components/AgentDepartmentSwitcher';
+import DepartmentDashboard from '../components/DepartmentDashboard';
+
+export default function DepartmentRouter() {
+  const { dept } = useParams();
+  const navigate = useNavigate();
+
+  return (
+    <div className="p-4 space-y-4">
+      <AgentDepartmentSwitcher value={dept} onChange={d => navigate(`/departments/${d}`)} />
+      <DepartmentDashboard department={dept} />
+    </div>
+  );
+}

--- a/dashboard/src/pages/FinanceDesk.jsx
+++ b/dashboard/src/pages/FinanceDesk.jsx
@@ -1,0 +1,4 @@
+import DepartmentDashboard from '../components/DepartmentDashboard';
+export default function FinanceDesk() {
+  return <DepartmentDashboard department="finance" />;
+}

--- a/dashboard/src/pages/ITMonitor.jsx
+++ b/dashboard/src/pages/ITMonitor.jsx
@@ -1,0 +1,4 @@
+import DepartmentDashboard from '../components/DepartmentDashboard';
+export default function ITMonitor() {
+  return <DepartmentDashboard department="it" />;
+}

--- a/dashboard/src/pages/MarketingHub.jsx
+++ b/dashboard/src/pages/MarketingHub.jsx
@@ -1,0 +1,4 @@
+import DepartmentDashboard from '../components/DepartmentDashboard';
+export default function MarketingHub() {
+  return <DepartmentDashboard department="marketing" />;
+}

--- a/dashboard/src/pages/OpsCenter.jsx
+++ b/dashboard/src/pages/OpsCenter.jsx
@@ -1,0 +1,4 @@
+import DepartmentDashboard from '../components/DepartmentDashboard';
+export default function OpsCenter() {
+  return <DepartmentDashboard department="operations" />;
+}

--- a/dashboard/src/pages/PeopleHub.jsx
+++ b/dashboard/src/pages/PeopleHub.jsx
@@ -1,0 +1,4 @@
+import DepartmentDashboard from '../components/DepartmentDashboard';
+export default function PeopleHub() {
+  return <DepartmentDashboard department="hr" />;
+}

--- a/dashboard/src/pages/SalesDashboard.jsx
+++ b/dashboard/src/pages/SalesDashboard.jsx
@@ -1,0 +1,4 @@
+import DepartmentDashboard from '../components/DepartmentDashboard';
+export default function SalesDashboard() {
+  return <DepartmentDashboard department="sales" />;
+}

--- a/dashboard/src/pages/SupportHub.jsx
+++ b/dashboard/src/pages/SupportHub.jsx
@@ -1,0 +1,4 @@
+import DepartmentDashboard from '../components/DepartmentDashboard';
+export default function SupportHub() {
+  return <DepartmentDashboard department="support" />;
+}

--- a/utils/agentLogSummarizer.js
+++ b/utils/agentLogSummarizer.js
@@ -1,0 +1,24 @@
+const { db } = require('../firebase');
+const getDepartmentAgents = require('./getDepartmentAgents');
+
+async function agentLogSummarizer(orgId, department) {
+  const agentMetas = getDepartmentAgents(department);
+  const agentIds = agentMetas.map(a => a.id);
+  const start = Date.now() - 7 * 24 * 60 * 60 * 1000;
+  const summary = {};
+
+  for (const id of agentIds) {
+    const snap = await db
+      .collection('orgs')
+      .doc(orgId)
+      .collection('logs')
+      .where('agent', '==', id)
+      .where('timestamp', '>=', new Date(start).toISOString())
+      .get();
+    summary[id] = snap.size;
+  }
+
+  return summary;
+}
+
+module.exports = agentLogSummarizer;

--- a/utils/getDepartmentAgents.js
+++ b/utils/getDepartmentAgents.js
@@ -1,0 +1,11 @@
+const catalog = require('../agents/agent-catalog.json');
+const metadata = require('../agents/agent-metadata.json');
+
+function getDepartmentAgents(departmentName) {
+  const ids = catalog[departmentName] || [];
+  return ids
+    .map(id => (metadata[id] ? { id, ...metadata[id] } : null))
+    .filter(Boolean);
+}
+
+module.exports = getDepartmentAgents;

--- a/utils/knowledgeGraph.js
+++ b/utils/knowledgeGraph.js
@@ -1,0 +1,30 @@
+const { db } = require('../firebase');
+const catalog = require('../agents/agent-catalog.json');
+
+function getRelatedAgents(agentId) {
+  for (const agents of Object.values(catalog)) {
+    if (agents.includes(agentId)) {
+      return agents.filter(a => a !== agentId);
+    }
+  }
+  return [];
+}
+
+async function recordAgentInsight(orgId, agentId, insightType, data) {
+  if (!orgId || !agentId) return;
+  await db
+    .collection('shared-insights')
+    .doc(orgId)
+    .collection(agentId)
+    .add({ insightType, data, timestamp: new Date().toISOString() });
+}
+
+async function suggestAgentCollab(agentId /*, context*/ ) {
+  return getRelatedAgents(agentId);
+}
+
+module.exports = {
+  getRelatedAgents,
+  recordAgentInsight,
+  suggestAgentCollab,
+};


### PR DESCRIPTION
## Summary
- catalog agents by department
- build React components for browsing departmental agents
- add departmental pages and routing
- log summarization and inter-agent knowledge utilities

## Testing
- `npm test`
- `npm test` in `dashboard` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_6855f2c678f0832382d424a02527b5f2