### PR TITLE
Add system audit scripts and executive summary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 logs/*
 !logs/health-status.json
 !logs/lifecycle-log.json
+!logs/system-audit.json
 *.log
 npm-debug.log*
 yarn-debug.log*

--- a/docs/executive-summary.md
+++ b/docs/executive-summary.md
@@ -1,0 +1,25 @@
+# Executive Summary
+
+- Total Agents: 10
+- API Endpoints: 25
+- Frontend Components: 18
+- Dashboard Components: 4
+- Commits Merged: 148
+
+## Recent Process Log
+
+# Process Log
+
+
+## [2025-06-20]
+✅ Infra — Merge pull request #135 from Csp-Ai/codex/rebase-branch-and-retry-failed-patch
+
+## Recommended Next Tasks
+
+- [NEXT PRIORITY] Create agent-error-reporter.js to catch invalid responses from run() methods and log to /anomalies/
+- [NEXT PRIORITY] Add "export report as deck" feature in PDF logic using cover + agent outputs
+- [NEXT PRIORITY] Implement SOP templates for all agents under /sops
+- [NEXT PRIORITY] Build department-level analytics dashboard using Firestore data
+- [NEXT PRIORITY] Automate process-log agent execution in a GitHub Action post-merge
+
+Overall, progress aligns with the vision of modular AI agents interconnected across frontend and backend systems.

--- a/logs/system-audit.json
+++ b/logs/system-audit.json
@@ -1,0 +1,109 @@
+[
+  {
+    "timestamp": "2025-06-20T23:51:43.661Z",
+    "activeCounts": {
+      "CX / Marketing": 1,
+      "Documentation": 1,
+      "Data Extraction": 1,
+      "Analytics": 2,
+      "Governance": 4,
+      "Quality Assurance": 1
+    },
+    "duplicates": [],
+    "missingSOPs": [
+      "insights-agent",
+      "report-generator-agent",
+      "website-scanner-agent",
+      "data-analyst-agent",
+      "mentor-agent",
+      "board-agent",
+      "guardian-agent",
+      "codex-qa-agent",
+      "process-guardian-agent",
+      "vision-guard-agent"
+    ],
+    "inactiveAgents": [],
+    "table": [
+      {
+        "agent": "insights-agent",
+        "department": "CX / Marketing",
+        "active": true,
+        "hasRun": false,
+        "hasMetadata": true,
+        "hasSOP": false
+      },
+      {
+        "agent": "report-generator-agent",
+        "department": "Documentation",
+        "active": true,
+        "hasRun": false,
+        "hasMetadata": true,
+        "hasSOP": false
+      },
+      {
+        "agent": "website-scanner-agent",
+        "department": "Data Extraction",
+        "active": true,
+        "hasRun": true,
+        "hasMetadata": true,
+        "hasSOP": false
+      },
+      {
+        "agent": "data-analyst-agent",
+        "department": "Analytics",
+        "active": true,
+        "hasRun": true,
+        "hasMetadata": true,
+        "hasSOP": false
+      },
+      {
+        "agent": "mentor-agent",
+        "department": "Analytics",
+        "active": true,
+        "hasRun": true,
+        "hasMetadata": true,
+        "hasSOP": false
+      },
+      {
+        "agent": "board-agent",
+        "department": "Governance",
+        "active": true,
+        "hasRun": false,
+        "hasMetadata": true,
+        "hasSOP": false
+      },
+      {
+        "agent": "guardian-agent",
+        "department": "Governance",
+        "active": true,
+        "hasRun": false,
+        "hasMetadata": true,
+        "hasSOP": false
+      },
+      {
+        "agent": "codex-qa-agent",
+        "department": "Quality Assurance",
+        "active": true,
+        "hasRun": true,
+        "hasMetadata": true,
+        "hasSOP": false
+      },
+      {
+        "agent": "process-guardian-agent",
+        "department": "Governance",
+        "active": true,
+        "hasRun": true,
+        "hasMetadata": true,
+        "hasSOP": false
+      },
+      {
+        "agent": "vision-guard-agent",
+        "department": "Governance",
+        "active": true,
+        "hasRun": true,
+        "hasMetadata": true,
+        "hasSOP": false
+      }
+    ]
+  }
+]

--- a/scripts/generateExecutiveSummary.js
+++ b/scripts/generateExecutiveSummary.js
@@ -1,0 +1,59 @@
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const META_FILE = path.join(__dirname, '..', 'agents', 'agent-metadata.json');
+const INDEX_FILE = path.join(__dirname, '..', 'functions', 'index.js');
+const FRONTEND_DIR = path.join(__dirname, '..', 'frontend');
+const DASHBOARD_DIR = path.join(__dirname, '..', 'dashboard', 'src');
+const PROCESS_LOG = path.join(__dirname, '..', 'PROCESS_LOG.md');
+const OUTPUT_MD = path.join(__dirname, '..', 'docs', 'executive-summary.md');
+
+function countEndpoints() {
+  const data = fs.readFileSync(INDEX_FILE, 'utf8');
+  const matches = data.match(/app\.(get|post|put|delete)/g) || [];
+  return matches.length;
+}
+
+function countComponents(dir) {
+  if (!fs.existsSync(dir)) return 0;
+  return fs.readdirSync(dir).filter(f => f.endsWith('.jsx') || f.endsWith('.js')).length;
+}
+
+function generate() {
+  const metadata = JSON.parse(fs.readFileSync(META_FILE, 'utf8'));
+  const numAgents = Object.keys(metadata).length;
+  const numEndpoints = countEndpoints();
+  const numFrontend = countComponents(FRONTEND_DIR);
+  const numDashboard = countComponents(DASHBOARD_DIR);
+  const merges = parseInt(execSync('git log --oneline --merges | wc -l').toString().trim(), 10);
+  const processLog = fs.existsSync(PROCESS_LOG) ? fs.readFileSync(PROCESS_LOG, 'utf8').trim() : '';
+
+  const tasks = [
+    'Create agent-error-reporter.js to catch invalid responses from run() methods and log to /anomalies/',
+    'Add \"export report as deck\" feature in PDF logic using cover + agent outputs',
+    'Implement SOP templates for all agents under /sops',
+    'Build department-level analytics dashboard using Firestore data',
+    'Automate process-log agent execution in a GitHub Action post-merge'
+  ];
+
+  const md = `# Executive Summary\n\n` +
+    `- Total Agents: ${numAgents}\n` +
+    `- API Endpoints: ${numEndpoints}\n` +
+    `- Frontend Components: ${numFrontend}\n` +
+    `- Dashboard Components: ${numDashboard}\n` +
+    `- Commits Merged: ${merges}\n\n` +
+    `## Recent Process Log\n\n${processLog}\n\n` +
+    `## Recommended Next Tasks\n\n` +
+    tasks.map(t => `- [NEXT PRIORITY] ${t}`).join('\n') +
+    `\n\nOverall, progress aligns with the vision of modular AI agents interconnected across frontend and backend systems.`;
+
+  fs.writeFileSync(OUTPUT_MD, md);
+  console.log('Executive summary generated.');
+}
+
+if (require.main === module) {
+  generate();
+}
+
+module.exports = { generate };

--- a/scripts/systemAudit.js
+++ b/scripts/systemAudit.js
@@ -1,0 +1,93 @@
+const fs = require('fs');
+const path = require('path');
+
+const AGENTS_DIR = path.join(__dirname, '..', 'agents');
+const META_FILE = path.join(AGENTS_DIR, 'agent-metadata.json');
+const SOPS_DIR = path.join(__dirname, '..', 'sops');
+const LOG_FILE = path.join(__dirname, '..', 'logs', 'system-audit.json');
+
+function ensureLogFile() {
+  const dir = path.dirname(LOG_FILE);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  if (!fs.existsSync(LOG_FILE)) fs.writeFileSync(LOG_FILE, '[]', 'utf8');
+}
+
+function readLog() {
+  ensureLogFile();
+  try {
+    return JSON.parse(fs.readFileSync(LOG_FILE, 'utf8'));
+  } catch {
+    return [];
+  }
+}
+
+function writeLog(data) {
+  fs.writeFileSync(LOG_FILE, JSON.stringify(data, null, 2));
+}
+
+function sopExists(id) {
+  const exts = ['.md', '.json', '.txt'];
+  return exts.some(ext => fs.existsSync(path.join(SOPS_DIR, id + ext)));
+}
+
+function checkRunExport(id) {
+  const file = path.join(AGENTS_DIR, `${id}.js`);
+  if (!fs.existsSync(file)) return false;
+  try {
+    const mod = require(file);
+    return typeof mod.run === 'function';
+  } catch {
+    return false;
+  }
+}
+
+function audit() {
+  const metadata = JSON.parse(fs.readFileSync(META_FILE, 'utf8'));
+  const agentFiles = fs.readdirSync(AGENTS_DIR).filter(f => f.endsWith('.js'));
+  const results = [];
+  const counts = {};
+  const seen = new Set();
+  const duplicates = [];
+
+  const allAgents = new Set([
+    ...Object.keys(metadata),
+    ...agentFiles.map(f => path.basename(f, '.js')),
+  ]);
+
+  for (const id of allAgents) {
+    const meta = metadata[id];
+    if (seen.has(id)) duplicates.push(id);
+    seen.add(id);
+    const active = meta ? !!meta.enabled : false;
+    const dept = meta ? meta.category || 'Unknown' : 'Unknown';
+    if (active) counts[dept] = (counts[dept] || 0) + 1;
+    results.push({
+      agent: id,
+      department: dept,
+      active,
+      hasRun: checkRunExport(id),
+      hasMetadata: !!meta,
+      hasSOP: sopExists(id),
+    });
+  }
+
+  const summary = {
+    timestamp: new Date().toISOString(),
+    activeCounts: counts,
+    duplicates,
+    missingSOPs: results.filter(r => !r.hasSOP).map(r => r.agent),
+    inactiveAgents: results.filter(r => !r.active).map(r => r.agent),
+    table: results,
+  };
+
+  const log = readLog();
+  log.push(summary);
+  writeLog(log);
+  console.log(JSON.stringify(summary, null, 2));
+}
+
+if (require.main === module) {
+  audit();
+}
+
+module.exports = { audit };


### PR DESCRIPTION
## Summary
- add `systemAudit.js` script to audit agents and log results
- generate initial `system-audit.json` log entry
- add `generateExecutiveSummary.js` script
- create `docs/executive-summary.md` with repo progress and next steps
- track new audit log in `.gitignore`

## Testing
- `npm test`
- `node scripts/systemAudit.js`
- `node scripts/generateExecutiveSummary.js`


------
https://chatgpt.com/codex/tasks/task_e_6855f3541b508323bcff20642e8beb7d