### PR TITLE
Implement agent health tracking

### DIFF
--- a/frontend/AgentHealthDashboard.jsx
+++ b/frontend/AgentHealthDashboard.jsx
@@ -1,0 +1,52 @@
+import React, { useEffect, useState } from 'react';
+
+export default function AgentHealthDashboard() {
+  const [data, setData] = useState([]);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const res = await fetch('/logs/agent-health.json');
+        const json = await res.json();
+        if (Array.isArray(json)) setData(json);
+      } catch {
+        setData([]);
+      }
+    };
+    fetchData();
+  }, []);
+
+  return (
+    <div className="p-6 text-white">
+      <h1 className="text-2xl font-bold mb-4">Agent Health</h1>
+      <div className="overflow-auto">
+        <table className="min-w-full text-sm">
+          <thead>
+            <tr className="text-left">
+              <th className="p-2">Agent</th>
+              <th className="p-2">Runs</th>
+              <th className="p-2">Success %</th>
+              <th className="p-2">Avg Duration (ms)</th>
+              <th className="p-2">Last Active</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.map(a => {
+              const successRate = a.runs ? Math.round((a.successes / a.runs) * 100) : 0;
+              const rowClass = successRate < 50 ? 'text-red-400' : '';
+              return (
+                <tr key={a.agent} className={`border-t border-white/20 ${rowClass}`}> 
+                  <td className="p-2">{a.agent}</td>
+                  <td className="p-2">{a.runs}</td>
+                  <td className="p-2">{successRate}%</td>
+                  <td className="p-2">{a.avgDuration}</td>
+                  <td className="p-2">{a.lastActive ? new Date(a.lastActive).toLocaleString() : '-'}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/utils/agentHealthTracker.js
+++ b/utils/agentHealthTracker.js
@@ -1,0 +1,66 @@
+const fs = require('fs');
+const path = require('path');
+
+const HEALTH_FILE = path.join(__dirname, '..', 'logs', 'agent-health.json');
+const REPORT_DIR = path.join(__dirname, '..', 'reports', 'agent-health');
+
+function ensureFile() {
+  const dir = path.dirname(HEALTH_FILE);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  if (!fs.existsSync(HEALTH_FILE)) {
+    fs.writeFileSync(HEALTH_FILE, '[]', 'utf8');
+  }
+  if (!fs.existsSync(REPORT_DIR)) {
+    fs.mkdirSync(REPORT_DIR, { recursive: true });
+  }
+}
+
+function readHealth() {
+  ensureFile();
+  try {
+    return JSON.parse(fs.readFileSync(HEALTH_FILE, 'utf8'));
+  } catch {
+    return [];
+  }
+}
+
+function writeHealth(data) {
+  fs.writeFileSync(HEALTH_FILE, JSON.stringify(data, null, 2));
+}
+
+function recordRun(agent, success, durationMs) {
+  const health = readHealth();
+  let entry = health.find(e => e.agent === agent);
+  if (!entry) {
+    entry = { agent, runs: 0, successes: 0, failures: 0, avgDuration: 0, lastActive: null };
+    health.push(entry);
+  }
+  entry.runs += 1;
+  if (success) entry.successes += 1; else entry.failures += 1;
+  entry.avgDuration = Math.round((entry.avgDuration * (entry.runs - 1) + durationMs) / entry.runs);
+  entry.lastActive = new Date().toISOString();
+  writeHealth(health);
+}
+
+function generateWeeklySummary() {
+  const data = readHealth();
+  const summary = data.map(e => ({
+    agent: e.agent,
+    runs: e.runs,
+    successRate: e.runs ? parseFloat((e.successes / e.runs).toFixed(2)) : 0,
+    avgDuration: e.avgDuration,
+    lastActive: e.lastActive
+  }));
+  const file = path.join(REPORT_DIR, `${Date.now()}.json`);
+  fs.writeFileSync(file, JSON.stringify(summary, null, 2));
+}
+
+function scheduleWeeklySummary() {
+  const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+  generateWeeklySummary();
+  setInterval(generateWeeklySummary, WEEK_MS);
+}
+
+module.exports = { recordRun, scheduleWeeklySummary, generateWeeklySummary };


### PR DESCRIPTION
## Summary
- log agent run statistics in `utils/agentHealthTracker`
- track agent execution data in `executeAgent`
- schedule weekly summaries
- new dashboard component `AgentHealthDashboard`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855f6c495f48323a43f7eba9b0e7979