### PR TITLE
Add investor demo route

### DIFF
--- a/agents/agent-metadata.json
+++ b/agents/agent-metadata.json
@@ -28,7 +28,8 @@
     "lifecycle": "incubation",
     "status": "planned",
     "locale": "en-US",
-    "misaligned": false
+    "misaligned": false,
+    "visibleToDemo": true
   },
   "report-generator-agent": {
     "name": "Report Generator",
@@ -58,7 +59,8 @@
     "lifecycle": "incubation",
     "status": "planned",
     "locale": "en-US",
-    "misaligned": false
+    "misaligned": false,
+    "visibleToDemo": true
   },
   "website-scanner-agent": {
     "name": "Website Scanner Agent",
@@ -85,7 +87,8 @@
     ],
     "lifecycle": "production",
     "locale": "en-US",
-    "misaligned": false
+    "misaligned": false,
+    "visibleToDemo": true
   },
   "data-analyst-agent": {
     "name": "Data Analyst Agent",
@@ -113,7 +116,8 @@
     ],
     "lifecycle": "incubation",
     "locale": "en-US",
-    "misaligned": false
+    "misaligned": false,
+    "visibleToDemo": true
   },
   "mentor-agent": {
     "name": "Mentor Agent",

--- a/frontend/src/DemoPage.jsx
+++ b/frontend/src/DemoPage.jsx
@@ -1,0 +1,131 @@
+import React, { useEffect, useState } from 'react';
+import AgentTracker from './AgentTracker.jsx';
+
+const workflows = {
+  market: {
+    name: 'AI Market Analysis',
+    steps: ['website-scanner-agent', 'data-analyst-agent', 'insights-agent'],
+    inputs: { company: 'Acme Corp', url: 'https://example.com' }
+  },
+  sales: {
+    name: 'Sales Outreach Draft',
+    steps: ['insights-agent', 'report-generator-agent'],
+    inputs: { product: 'AI Widget', audience: 'Retailers' }
+  },
+  content: {
+    name: 'Content Plan',
+    steps: ['website-scanner-agent', 'insights-agent', 'report-generator-agent'],
+    inputs: { topic: 'AI Trends', audience: 'Executives' }
+  }
+};
+
+const sampleOutputs = {
+  'website-scanner-agent': 'Scanned website and extracted key metadata.',
+  'data-analyst-agent': 'Analyzed competitors and market positioning.',
+  'insights-agent': 'Generated actionable insights based on findings.',
+  'report-generator-agent': 'Compiled summary report for review.'
+};
+
+export default function DemoPage() {
+  const [agents, setAgents] = useState([]);
+  const [flow, setFlow] = useState('market');
+  const [inputs, setInputs] = useState(workflows['market'].inputs);
+  const [status, setStatus] = useState([]);
+  const [results, setResults] = useState([]);
+
+  useEffect(() => {
+    fetch('/demo-agents')
+      .then(r => r.json())
+      .then(setAgents)
+      .catch(() => setAgents([]));
+  }, []);
+
+  useEffect(() => {
+    setInputs(workflows[flow].inputs);
+  }, [flow]);
+
+  const runDemo = () => {
+    const steps = workflows[flow].steps;
+    setStatus(steps.map((_, i) => (i === 0 ? 'active' : 'pending')));
+    setResults([]);
+    let idx = 0;
+    const next = () => {
+      if (idx >= steps.length) {
+        fetch('/logs/demo-sessions', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ workflow: flow, inputs })
+        }).catch(() => {});
+        return;
+      }
+      const agent = steps[idx];
+      setTimeout(() => {
+        setResults(r => [...r, { agent, output: sampleOutputs[agent] || 'Demo output' }]);
+        setStatus(s => {
+          const copy = [...s];
+          copy[idx] = 'completed';
+          if (idx + 1 < copy.length) copy[idx + 1] = 'active';
+          return copy;
+        });
+        idx++;
+        next();
+      }, 600);
+    };
+    next();
+  };
+
+  const updateInput = (key, value) => setInputs(i => ({ ...i, [key]: value }));
+
+  const flowData = workflows[flow];
+
+  return (
+    <div className="min-h-screen bg-gray-50 p-6 space-y-6">
+      <h1 className="text-3xl font-bold text-center">Investor Demo Sandbox</h1>
+      <div className="flex flex-col md:flex-row gap-6">
+        <div className="md:w-1/3 space-y-4">
+          <select
+            className="w-full p-2 rounded border"
+            value={flow}
+            onChange={e => setFlow(e.target.value)}
+          >
+            {Object.entries(workflows).map(([k, v]) => (
+              <option key={k} value={k}>{v.name}</option>
+            ))}
+          </select>
+          {Object.entries(inputs).map(([k, v]) => (
+            <input
+              key={k}
+              value={v}
+              onChange={e => updateInput(k, e.target.value)}
+              className="w-full p-2 rounded border"
+              placeholder={k}
+            />
+          ))}
+          <button
+            onClick={runDemo}
+            className="w-full bg-blue-600 hover:bg-blue-700 text-white p-2 rounded"
+          >
+            Run Simulation
+          </button>
+        </div>
+        <div className="md:flex-1 space-y-4">
+          <AgentTracker steps={flowData.steps} status={status} />
+          {results.map((r, i) => (
+            <div key={i} className="bg-white rounded shadow p-4">
+              <h3 className="font-semibold mb-2">{r.agent}</h3>
+              <pre className="text-sm whitespace-pre-wrap">{r.output}</pre>
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className="text-center space-x-4">
+        <a href="/book" className="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded">Book Demo</a>
+        <a href="/waitlist" className="bg-purple-600 hover:bg-purple-700 text-white px-4 py-2 rounded">Join Waitlist</a>
+        <a href="/dashboard" className="bg-gray-600 hover:bg-gray-700 text-white px-4 py-2 rounded">See Full Stack</a>
+      </div>
+      <p className="text-center text-sm text-gray-500">
+        <a href="/docs/executive-summary.md" className="underline">Executive Summary</a>
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -3,12 +3,20 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import LandingPage from './LandingPage.jsx'
 import DevToolsPanel from './DevToolsPanel.jsx'
+import DemoPage from './DemoPage.jsx'
+
+const path = window.location.pathname;
+const isDemo = path.startsWith('/demo');
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <>
-      <LandingPage />
-      <DevToolsPanel />
-    </>
+    {isDemo ? (
+      <DemoPage />
+    ) : (
+      <>
+        <LandingPage />
+        <DevToolsPanel />
+      </>
+    )}
   </StrictMode>
 )

--- a/functions/index.js
+++ b/functions/index.js
@@ -172,6 +172,7 @@ const SESSION_STATUS_FILE = path.join(LOG_DIR, 'sessionStatus.json');
 const SESSION_LOG_DIR = path.join(LOG_DIR, 'sessions');
 const REPORTS_DIR = path.join(LOG_DIR, 'reports');
 const SIMULATION_DIR = path.join(LOG_DIR, 'simulations');
+const DEMO_SESSION_DIR = path.join(LOG_DIR, 'demo-sessions');
 
 // Ensure reports directory exists so generated PDFs can be served
 if (!fs.existsSync(REPORTS_DIR)) {
@@ -238,6 +239,12 @@ function ensureSimulationDir() {
   }
 }
 
+function ensureDemoSessionDir() {
+  if (!fs.existsSync(DEMO_SESSION_DIR)) {
+    fs.mkdirSync(DEMO_SESSION_DIR, { recursive: true });
+  }
+}
+
 function readSessionStatus() {
   ensureSessionFiles();
   try {
@@ -286,6 +293,12 @@ function saveSimulationLog(orgId, timestamp, data) {
     fs.mkdirSync(dir, { recursive: true });
   }
   const file = path.join(dir, `${timestamp}.json`);
+  fs.writeFileSync(file, JSON.stringify(data, null, 2));
+}
+
+function saveDemoSession(data) {
+  ensureDemoSessionDir();
+  const file = path.join(DEMO_SESSION_DIR, `${Date.now()}.json`);
   fs.writeFileSync(file, JSON.stringify(data, null, 2));
 }
 
@@ -968,6 +981,24 @@ app.post('/logs/simulations', async (req, res) => {
     saveSimulationLog(orgId || 'default', timestamp, { agents, log });
     res.json({ success: true });
   } catch (err) {
+    res.status(500).json({ error: 'failed to save' });
+  }
+});
+
+app.get('/demo-agents', (_req, res) => {
+  const list = Object.entries(agentMetadata)
+    .filter(([, m]) => m.visibleToDemo)
+    .map(([id, m]) => ({ id, name: m.name, description: m.description }));
+  res.json(list);
+});
+
+app.post('/logs/demo-sessions', (req, res) => {
+  const { workflow = '', inputs = {} } = req.body || {};
+  if (!workflow) return res.status(400).json({ error: 'workflow required' });
+  try {
+    saveDemoSession({ workflow, inputs, timestamp: new Date().toISOString() });
+    res.json({ success: true });
+  } catch {
     res.status(500).json({ error: 'failed to save' });
   }
 });


### PR DESCRIPTION
## Summary
- show investor friendly demo page with workflows under `/demo`
- expose `/demo-agents` API for demo agent metadata
- log demo usage under `/logs/demo-sessions`
- mark key agents visible in demo

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6855f6e1fd9c83238a8a834b3c9feaac