### PR TITLE
Track agent usage per org

### DIFF
--- a/functions/simulateAgent.js
+++ b/functions/simulateAgent.js
@@ -1,6 +1,8 @@
 const { functions } = require('../firebase');
 const { db } = require('./db');
 const { getRegisteredAgents } = require('../utils/agentTools');
+const crypto = require('crypto');
+const { appendUsageLog } = require('./usageLogger');
 
 async function handler(req, res) {
   if (req.method !== 'POST') return res.status(405).end();
@@ -13,12 +15,16 @@ async function handler(req, res) {
 
   let agentResponse = null;
   const log = [];
+  const start = Date.now();
+  const inputHash = crypto.createHash('sha256').update(JSON.stringify(input)).digest('hex');
+  let status = 'success';
   try {
     log.push('executing agent');
     agentResponse = await Promise.resolve(agent.run(input));
     log.push('completed');
   } catch (err) {
     log.push('error: ' + err.message);
+    status = 'error';
     return res.status(500).json({ error: err.message, log });
   } finally {
     try {
@@ -31,6 +37,13 @@ async function handler(req, res) {
           .doc(ts)
           .set({ agentId, input, response: agentResponse, log, timestamp: new Date().toISOString() });
       }
+      appendUsageLog(orgId || 'default', agentId, {
+        timestamp: new Date().toISOString(),
+        userId: req.body.userId || null,
+        inputHash,
+        status,
+        duration: Date.now() - start
+      });
     } catch (err) {
       console.error('Failed to log simulation:', err.message);
     }

--- a/functions/usageLogger.js
+++ b/functions/usageLogger.js
@@ -1,0 +1,28 @@
+const fs = require('fs');
+const path = require('path');
+
+const USAGE_DIR = path.join(__dirname, '..', 'logs', 'usage');
+
+function ensureDir(orgId) {
+  const dir = path.join(USAGE_DIR, orgId || 'default');
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function appendUsageLog(orgId, agentId, entry) {
+  const dir = ensureDir(orgId);
+  const file = path.join(dir, `${agentId}.json`);
+  let logs = [];
+  if (fs.existsSync(file)) {
+    try {
+      logs = JSON.parse(fs.readFileSync(file, 'utf8'));
+      if (!Array.isArray(logs)) logs = [];
+    } catch {
+      logs = [];
+    }
+  }
+  logs.push(entry);
+  fs.writeFileSync(file, JSON.stringify(logs, null, 2));
+}
+
+module.exports = { appendUsageLog };

--- a/utils/getAgentUsageStats.js
+++ b/utils/getAgentUsageStats.js
@@ -1,0 +1,61 @@
+const fs = require('fs');
+const path = require('path');
+const catalog = require('../agents/agent-catalog.json');
+
+function getAgentUsageStats() {
+  const usageDir = path.join(__dirname, '..', 'logs', 'usage');
+  if (!fs.existsSync(usageDir)) {
+    return { mostUsedAgents: [], avgRunTime: {}, totalInvocations: {} };
+  }
+
+  const deptByAgent = {};
+  for (const [dept, ids] of Object.entries(catalog)) {
+    for (const id of ids) {
+      deptByAgent[id] = dept;
+    }
+  }
+
+  const agentCounts = {};
+  const durationTotals = {};
+  const durationCounts = {};
+  const orgStats = {};
+
+  for (const org of fs.readdirSync(usageDir)) {
+    const orgPath = path.join(usageDir, org);
+    if (!fs.statSync(orgPath).isDirectory()) continue;
+    const deptCounts = {};
+    orgStats[org] = deptCounts;
+    for (const file of fs.readdirSync(orgPath)) {
+      if (!file.endsWith('.json')) continue;
+      const agentId = path.basename(file, '.json');
+      let entries;
+      try {
+        entries = JSON.parse(fs.readFileSync(path.join(orgPath, file), 'utf8'));
+      } catch {
+        entries = [];
+      }
+      if (!Array.isArray(entries)) continue;
+      const count = entries.length;
+      agentCounts[agentId] = (agentCounts[agentId] || 0) + count;
+      const dept = deptByAgent[agentId] || 'unknown';
+      deptCounts[dept] = (deptCounts[dept] || 0) + count;
+      for (const e of entries) {
+        durationTotals[agentId] = (durationTotals[agentId] || 0) + (e.duration || 0);
+        durationCounts[agentId] = (durationCounts[agentId] || 0) + 1;
+      }
+    }
+  }
+
+  const mostUsedAgents = Object.entries(agentCounts)
+    .sort((a, b) => b[1] - a[1])
+    .map(([agentId, count]) => ({ agentId, count }));
+
+  const avgRunTime = {};
+  for (const agentId of Object.keys(durationTotals)) {
+    avgRunTime[agentId] = durationTotals[agentId] / (durationCounts[agentId] || 1);
+  }
+
+  return { mostUsedAgents, avgRunTime, totalInvocations: orgStats };
+}
+
+module.exports = getAgentUsageStats;


### PR DESCRIPTION
## Summary
- log every agent run to `logs/usage/{orgId}/{agentId}.json`
- add shared `usageLogger` helper
- store usage data from simulation endpoint
- expose `utils/getAgentUsageStats.js` to read usage logs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855f7ce187c8323a90c129fb0eba663