### PR TITLE
Combine overlay and route features

### DIFF
--- a/frontend/src/OnboardingOverlay.jsx
+++ b/frontend/src/OnboardingOverlay.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+
+export default function OnboardingOverlay({ onComplete }) {
+  return (
+    <motion.div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+    >
+      <div className="bg-white rounded-lg p-6 text-center shadow-xl">
+        <h2 className="text-2xl font-bold mb-4">Onboarding</h2>
+        <p className="mb-4">Let's get you set up.</p>
+        <button
+          onClick={onComplete}
+          className="px-4 py-2 bg-blue-600 text-white rounded"
+        >
+          Start
+        </button>
+      </div>
+    </motion.div>
+  );
+}

--- a/frontend/src/UseCaseSelector.jsx
+++ b/frontend/src/UseCaseSelector.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+const useCases = [
+  { id: 'market-analysis', name: 'Market Analysis', desc: 'Understand your market with AI insights.' },
+  { id: 'sales-outreach', name: 'Sales Outreach', desc: 'Draft personalized sales outreach at scale.' },
+  { id: 'content-planning', name: 'Content Planning', desc: 'Plan engaging content ideas.' }
+];
+
+export default function UseCaseSelector() {
+  return (
+    <div className="min-h-screen bg-gray-50 p-6">
+      <h1 className="text-3xl font-bold mb-6">Explore Use Cases</h1>
+      <div className="grid gap-4 md:grid-cols-3">
+        {useCases.map(u => (
+          <div key={u.id} className="border rounded-lg p-4 bg-white shadow-sm">
+            <h2 className="font-semibold mb-1">{u.name}</h2>
+            <p className="text-sm text-gray-600 mb-4">{u.desc}</p>
+            <a href={`/demo?case=${u.id}`} className="text-blue-600 hover:underline">Run Demo</a>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/WelcomeExperience.jsx
+++ b/frontend/src/WelcomeExperience.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+
+export default function WelcomeExperience({ onFinish }) {
+  return (
+    <motion.div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+    >
+      <div className="bg-white rounded-lg p-6 max-w-md text-center shadow-xl">
+        <h2 className="text-2xl font-bold mb-4">Getting Started</h2>
+        <p className="mb-4">This short tour will walk you through the basics.</p>
+        <button
+          onClick={onFinish}
+          className="px-4 py-2 bg-green-600 text-white rounded"
+        >
+          Finish
+        </button>
+      </div>
+    </motion.div>
+  );
+}

--- a/frontend/src/WelcomeOverlay.jsx
+++ b/frontend/src/WelcomeOverlay.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+
+export default function WelcomeOverlay({ onDismiss }) {
+  return (
+    <motion.div
+      className="fixed inset-0 z-40 flex items-center justify-center bg-black/60"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+    >
+      <div className="bg-white rounded-lg p-6 text-center shadow-xl">
+        <h2 className="text-2xl font-bold mb-4">Welcome!</h2>
+        <p className="mb-4">Thanks for trying the AI agent demo.</p>
+        <button
+          onClick={onDismiss}
+          className="px-4 py-2 bg-blue-600 text-white rounded"
+        >
+          Continue
+        </button>
+      </div>
+    </motion.div>
+  );
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,22 +1,82 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import LandingPage from './LandingPage.jsx'
-import DevToolsPanel from './DevToolsPanel.jsx'
-import DemoPage from './DemoPage.jsx'
+import { StrictMode, useState } from 'react';
+import { createRoot } from 'react-dom/client';
+import { AnimatePresence } from 'framer-motion';
+import './index.css';
+import LandingPage from './LandingPage.jsx';
+import DevToolsPanel from './DevToolsPanel.jsx';
+import DemoPage from './DemoPage.jsx';
+import UseCaseSelector from './UseCaseSelector.jsx';
+import WelcomeOverlay from './WelcomeOverlay.jsx';
+import WelcomeExperience from './WelcomeExperience.jsx';
+import OnboardingOverlay from './OnboardingOverlay.jsx';
+import AgentsGallery from '../AgentsGallery.jsx';
 
 const path = window.location.pathname;
-const isDemo = path.startsWith('/demo');
 
-createRoot(document.getElementById('root')).render(
-  <StrictMode>
-    {isDemo ? (
-      <DemoPage />
-    ) : (
+function App() {
+  const isDemo = path.startsWith('/demo');
+  const isGallery = path.startsWith('/gallery');
+  const isUseCases = path.startsWith('/use-cases');
+
+  const [onboarded, setOnboarded] = useState(
+    localStorage.getItem('onboarded') === 'true'
+  );
+  const [experienceSeen, setExperienceSeen] = useState(
+    localStorage.getItem('welcomeExperienceSeen') === 'true'
+  );
+  const [welcomeDismissed, setWelcomeDismissed] = useState(
+    localStorage.getItem('welcomeOverlayDismissed') === 'true'
+  );
+
+  const markOnboarded = () => {
+    localStorage.setItem('onboarded', 'true');
+    setOnboarded(true);
+  };
+
+  const finishExperience = () => {
+    localStorage.setItem('welcomeExperienceSeen', 'true');
+    setExperienceSeen(true);
+  };
+
+  const dismissWelcome = () => {
+    localStorage.setItem('welcomeOverlayDismissed', 'true');
+    setWelcomeDismissed(true);
+  };
+
+  let content;
+  if (isDemo) {
+    content = <DemoPage />;
+  } else if (isGallery) {
+    content = <AgentsGallery />;
+  } else if (isUseCases) {
+    content = <UseCaseSelector />;
+  } else {
+    content = (
       <>
         <LandingPage />
         <DevToolsPanel />
       </>
-    )}
+    );
+  }
+
+  return (
+    <>
+      {content}
+      <AnimatePresence>
+        {!onboarded && <OnboardingOverlay onComplete={markOnboarded} />}
+        {onboarded && !experienceSeen && (
+          <WelcomeExperience onFinish={finishExperience} />
+        )}
+        {onboarded && experienceSeen && !welcomeDismissed && (
+          <WelcomeOverlay onDismiss={dismissWelcome} />
+        )}
+      </AnimatePresence>
+    </>
+  );
+}
+
+createRoot(document.getElementById('root')).render(
+  <StrictMode>
+    <App />
   </StrictMode>
-)
+);


### PR DESCRIPTION
## Summary
- add `UseCaseSelector` for `/use-cases`
- create `WelcomeOverlay`, `WelcomeExperience`, and `OnboardingOverlay`
- consolidate imports and routing logic in `main.jsx`
- register `/gallery` and new overlays with correct precedence

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855fd30efc88323a091e1119fc6092b