### PR TITLE
Add Vercel configuration for frontend routing and Cloud Run proxy

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,10 @@
+{
+  "cleanUrls": true,
+  "rewrites": [
+    { "source": "/api/:path*", "destination": "https://your-cloud-run-api-url.com/api/:path*" },
+    { "source": "/:path*", "destination": "/index.html" }
+  ],
+  "env": {
+    "REACT_APP_API_BASE": "https://your-cloud-run-api-url.com"
+  }
+}


### PR DESCRIPTION
## Summary
- configure Vercel deployment to serve React frontend as an SPA
- proxy `/api` requests to the Cloud Run backend
- set default `REACT_APP_API_BASE` environment variable for Vercel

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685602f8a068832396bb0b917c5228a1