### PR TITLE
Fix SPA fallback with rewrites for Vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,6 @@
 {
   "version": 2,
+  "cleanUrls": true,
   "builds": [
     {
       "src": "frontend/package.json",
@@ -7,10 +8,7 @@
       "config": { "distDir": "build" }
     }
   ],
-  "routes": [
-    { "src": "/(.*)", "dest": "/index.html" }
-  ],
   "rewrites": [
-    { "source": "/:path*", "destination": "/index.html" }
+    { "source": "/(.*)", "destination": "/index.html" }
   ]
 }


### PR DESCRIPTION
## Summary
- use `rewrites` instead of `routes` in `vercel.json`
- enable `cleanUrls`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68560b11eafc8323a27346947aa36a33