### PR TITLE
Improve SWAT agent CLI runner

### DIFF
--- a/core/agent-runner.js
+++ b/core/agent-runner.js
@@ -1,0 +1,51 @@
+const chalk = require('chalk');
+
+/**
+ * Run the Vercel SWAT agent with optional environment overrides.
+ * @param {Object} params
+ * @param {string} params.sessionId
+ * @param {Array} params.registeredAgents
+ * @param {Object} params.vercelConfig
+ * @param {Object} [params.envOverrides]
+ * @returns {Promise<Object>} log summary from the agent
+ */
+async function run({ sessionId = '', registeredAgents = [], vercelConfig = {}, envOverrides = {} } = {}) {
+  try {
+    if (envOverrides && typeof envOverrides === 'object') {
+      for (const [key, value] of Object.entries(envOverrides)) {
+        process.env[key] = value;
+      }
+    }
+
+    const requiredDeps = ['node-fetch', 'firebase-admin'];
+    const missing = requiredDeps.filter(dep => {
+      try {
+        require.resolve(dep);
+        return false;
+      } catch {
+        return true;
+      }
+    });
+    if (missing.length) {
+      console.error(chalk.redBright(`Missing dependencies: ${missing.join(', ')}`));
+      throw new Error('Required dependencies not installed');
+    }
+
+    const agentModule = await import('../agents/vercel-swat-agent.js');
+    const agent = agentModule.default || agentModule;
+    if (!agent || typeof agent.run !== 'function') {
+      console.error(chalk.redBright('vercel-swat-agent.js is missing a valid exported `run()` function'));
+      throw new Error('Invalid agent module');
+    }
+
+    console.log(chalk.cyanBright('\n🚀 Running Vercel SWAT Agent...'));
+    const result = await agent.run({ sessionId, registeredAgents, vercelConfig });
+    console.log(chalk.green('\n✅ SWAT Agent completed successfully.'));
+    return result;
+  } catch (err) {
+    console.error(chalk.redBright('\n❌ Vercel SWAT Agent failed with reason:'), err.message);
+    throw err;
+  }
+}
+
+module.exports = { run };

--- a/run-swat-agent.js
+++ b/run-swat-agent.js
@@ -24,12 +24,22 @@ require('dotenv').config();
 (async () => {
   try {
     const { run } = await import('./core/agent-runner.js');
-    const vercelConfig = require('./vercel.json');
-    const result = await run('vercel-swat-agent', {
-      sessionId: 'dev-session',
-      registeredAgents: [],
-      vercelConfig,
-    });
+    const vercelConfig = JSON.parse(fs.readFileSync('./vercel.json', 'utf8'));
+
+    const args = process.argv.slice(2);
+    let sessionId = process.env.SESSION_ID || 'dev-session';
+    const envOverrides = {};
+    for (const arg of args) {
+      if (arg.startsWith('--session=')) {
+        sessionId = arg.slice('--session='.length);
+      } else if (arg.startsWith('--env=')) {
+        const pair = arg.slice('--env='.length);
+        const [key, value] = pair.split('=');
+        envOverrides[key] = value;
+      }
+    }
+
+    const result = await run({ sessionId, registeredAgents: [], vercelConfig, envOverrides });
     console.log(JSON.stringify(result, null, 2));
     console.log('✅ Vercel SWAT Agent completed successfully');
   } catch (err) {


### PR DESCRIPTION
## Summary
- add new `core/agent-runner.js` that wraps `vercel-swat-agent.js`
- support environment overrides and dependency checks
- update `run-swat-agent.js` to use the new runner and parse CLI args

## Testing
- `npm test`
- `node run-swat-agent.js --session=test123 --env TEST_VAR=hello` *(fails: Missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68561ba5b4e883239cc8bd5c58c65061