### PR TITLE
Fix Firebase admin initialization

### DIFF
--- a/agents/vercel-swat-agent.js
+++ b/agents/vercel-swat-agent.js
@@ -5,6 +5,18 @@ const { execSync } = require('child_process');
 const admin = require('firebase-admin');
 const chalk = require('chalk');
 
+if (!admin.apps.length) {
+  try {
+    admin.initializeApp({
+      credential: admin.credential.applicationDefault()
+    });
+  } catch {
+    console.error(chalk.redBright("\uD83D\uDD25 Firebase config missing. Skipping initialization."));
+  }
+}
+
+const db = admin.apps.length ? admin.firestore() : null;
+
 const LOG_DIR = path.join(__dirname, '..', 'logs');
 const LOG_FILE = path.join(LOG_DIR, 'logs.json');
 
@@ -44,7 +56,7 @@ async function checkEndpoint(url, timeoutMs = 5000) {
 
 module.exports = {
   run: async ({ sessionId = '', registeredAgents = [] } = {}) => {
-    const firestore = admin.firestore();
+    const firestore = db;
     const diagnosticReport = [];
     const autoFixSummary = [];
     const fallbackTriggerLog = [];

--- a/firebase.js
+++ b/firebase.js
@@ -1,26 +1,16 @@
 const admin = require('firebase-admin');
-const functions = require('firebase-functions');
+const chalk = require('chalk');
 
-// Your Cloud Functions code here, using the imported admin and functions objects
+let db = null;
+try {
+  if (!admin.apps.length) {
+    admin.initializeApp({
+      credential: admin.credential.applicationDefault()
+    });
+  }
+  db = admin.firestore();
+} catch {
+  console.error(chalk.redBright("\uD83D\uDD25 Firebase config missing. Skipping initialization."));
+}
 
-+-----------------------------------------------------+
-|                firebase.js                          |
-+-----------------------------------------------------+
-| 1. Import modules:                                  |
-|    - firebase-admin                                 |
-|    - firebase-functions                             |
-+-----------------------------------------------------+
-| 2. Define firebaseConfig:                           |
-|    - Reads from environment variables               |
-|    - Uses fallback/default values if not set        |
-+-----------------------------------------------------+
-| 3. Initialize Firebase Admin SDK:                   |
-|    - Only if not already initialized                |
-|    - Uses GOOGLE_APPLICATION_CREDENTIALS for auth   |
-|    - Passes firebaseConfig                          |
-+-----------------------------------------------------+
-| 4. Export:                                          |
-|    - admin (firebase-admin instance)                |
-|    - functions (firebase-functions)                 |
-|    - firebaseConfig                                 |
-+-----------------------------------------------------+
+module.exports = { admin, db };


### PR DESCRIPTION
## Summary
- safely initialize Firebase Admin on load
- initialize Firestore for the SWAT agent and use the shared DB
- guard Firestore helpers if Firebase config missing

## Testing
- `npm test`
- `node run-swat-agent.js --session=test123 --env TEST_VAR=ready`

------
https://chatgpt.com/codex/tasks/task_e_6856211aae608323a3690fa9a152a70c