### PR TITLE
Fix FeedbackFab emoji syntax

### DIFF
--- a/frontend/src/FeedbackFab.jsx
+++ b/frontend/src/FeedbackFab.jsx
@@ -53,7 +53,7 @@ export default function FeedbackFab({ agent }) {
           title="Give Feedback"
           className="fixed bottom-6 right-6 bg-blue-600 text-white w-12 h-12 rounded-full flex items-center justify-center shadow-lg z-40"
         >
-          \u{1F4AC}
+          {"\u{1F4AC}"}
         </button>
       )}
       {open && (


### PR DESCRIPTION
## Summary
- escape emoji string in FeedbackFab to produce valid JSX

## Testing
- `npm test`
- `node -e "const fs=require('fs');const acorn=require('acorn');const jsx=require('acorn-jsx');const code=fs.readFileSync('frontend/src/FeedbackFab.jsx','utf8');try{acorn.Parser.extend(jsx()).parse(code,{ecmaVersion:2020,sourceType:'module'});console.log('ok');}catch(e){console.error('err',e.message);}"`


------
https://chatgpt.com/codex/tasks/task_e_68562b9bdde8832395c4a0c4a969c170