### PR TITLE
Fix Firebase init in frontend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+VITE_FIREBASE_API_KEY=your-api-key
+VITE_FIREBASE_AUTH_DOMAIN=your-auth-domain
+VITE_FIREBASE_PROJECT_ID=your-project-id

--- a/frontend/src/firebase.js
+++ b/frontend/src/firebase.js
@@ -2,24 +2,36 @@ import { initializeApp } from 'firebase/app';
 import { getAuth } from 'firebase/auth';
 import { getFirestore } from 'firebase/firestore';
 
-const firebaseConfig = {
-  apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
-  authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN,
-  projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID,
+let app = null;
+let db = {};
+
+// Fallback auth stub so UI components can safely call auth methods
+let auth = {
+  currentUser: null,
+  signInAnonymously: async () => {
+    console.warn('Firebase auth stub invoked: signInAnonymously');
+    return { user: null };
+  },
 };
 
-let app;
-let db;
-let auth;
+const apiKey = import.meta.env.VITE_FIREBASE_API_KEY;
 
-try {
-  app = initializeApp(firebaseConfig);
-  db = getFirestore(app);
-  auth = getAuth(app);
-} catch (err) {
-  console.error('Failed to initialize Firebase:', err);
-  db = {};
-  auth = { currentUser: null };
+if (apiKey) {
+  const firebaseConfig = {
+    apiKey,
+    authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN,
+    projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID,
+  };
+
+  try {
+    app = initializeApp(firebaseConfig);
+    db = getFirestore(app);
+    auth = getAuth(app);
+  } catch (err) {
+    console.error('Failed to initialize Firebase:', err);
+  }
+} else {
+  console.warn('VITE_FIREBASE_API_KEY is not defined. Firebase not initialized.');
 }
 
 export { db, auth };


### PR DESCRIPTION
## Summary
- prevent Firebase from crashing if credentials are missing
- include helpful fallback stub for auth
- log issues instead of stopping the UI
- provide `.env.example` so devs set needed vars

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685630dcc5848323b69ace423a1f5a6e