### PR TITLE
Add neural agent map visualization components

### DIFF
--- a/dashboard/src/components/AgentLink.jsx
+++ b/dashboard/src/components/AgentLink.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+
+export default function AgentLink({ source, target, isActive }) {
+  if (!source || !target) return null;
+  const midX = (source.x + target.x) / 2;
+  const midY = Math.min(source.y, target.y) - 40;
+  const d = `M ${source.x} ${source.y} Q ${midX} ${midY} ${target.x} ${target.y}`;
+  return (
+    <motion.path
+      d={d}
+      stroke="#0ff"
+      strokeWidth={2}
+      fill="none"
+      initial={false}
+      animate={isActive ? { opacity: 1, pathLength: [0, 1, 0] } : { opacity: 0.4, pathLength: 1 }}
+      transition={isActive ? { duration: 1.2, repeat: Infinity } : { duration: 0.4 }}
+    />
+  );
+}

--- a/dashboard/src/components/AgentNode.jsx
+++ b/dashboard/src/components/AgentNode.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+
+export default function AgentNode({ icon, color = '#06b6d4', name, isActive }) {
+  return (
+    <motion.div
+      className="flex items-center justify-center w-10 h-10 rounded-full text-xl text-white select-none"
+      style={{ backgroundColor: color }}
+      title={name}
+      animate={isActive ? { scale: [1, 1.2, 1], boxShadow: '0 0 12px rgba(0,255,255,0.8)' } : { boxShadow: '0 0 4px rgba(0,0,0,0.5)' }}
+      transition={isActive ? { repeat: Infinity, duration: 1.2 } : { duration: 0.3 }}
+    >
+      {icon}
+    </motion.div>
+  );
+}

--- a/dashboard/src/components/NeuralAgentMap.jsx
+++ b/dashboard/src/components/NeuralAgentMap.jsx
@@ -1,0 +1,95 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import AgentNode from './AgentNode.jsx';
+import AgentLink from './AgentLink.jsx';
+import parseLogs from '../../../utils/parseAgentLogs.js';
+
+export default function NeuralAgentMap({ agents = [], logEvents = [] }) {
+  const containerRef = useRef(null);
+  const [size, setSize] = useState({ width: 0, height: 0 });
+  const [links, setLinks] = useState([]);
+  const processed = useRef(0);
+  const expireMs = 4000; // 3-5s
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+    const rect = containerRef.current.getBoundingClientRect();
+    setSize({ width: rect.width, height: rect.height });
+  }, [agents]);
+
+  useEffect(() => {
+    const newMsgs = logEvents.slice(processed.current);
+    processed.current = logEvents.length;
+    const updates = parseLogs(newMsgs);
+    if (updates.length) {
+      const now = Date.now();
+      setLinks(ls => [
+        ...ls,
+        ...updates.map(u => ({ ...u, key: now + Math.random(), expires: now + expireMs }))
+      ]);
+    }
+  }, [logEvents]);
+
+  useEffect(() => {
+    const t = setInterval(() => {
+      const now = Date.now();
+      setLinks(ls => ls.filter(l => l.expires > now));
+    }, 1000);
+    return () => clearInterval(t);
+  }, []);
+
+  const indexMap = useMemo(() => {
+    const m = {};
+    agents.forEach((a, i) => { m[a.name] = i; });
+    return m;
+  }, [agents]);
+
+  const positions = useMemo(() => {
+    if (!size.width || !size.height) return [];
+    const r = Math.min(size.width, size.height) / 2 - 30;
+    return agents.map((_, i) => {
+      const angle = (i / agents.length) * Math.PI * 2;
+      return {
+        x: size.width / 2 + Math.cos(angle) * r,
+        y: size.height / 2 + Math.sin(angle) * r
+      };
+    });
+  }, [size, agents]);
+
+  const activeNodes = useMemo(() => {
+    const s = new Set();
+    links.forEach(l => { s.add(l.from); s.add(l.to); });
+    return s;
+  }, [links]);
+
+  return (
+    <div ref={containerRef} className="relative w-full h-full">
+      <svg className="absolute inset-0 w-full h-full pointer-events-none">
+        {links.map(link => {
+          const sPos = positions[indexMap[link.from]];
+          const tPos = positions[indexMap[link.to]];
+          if (!sPos || !tPos) return null;
+          return (
+            <AgentLink key={link.key} source={sPos} target={tPos} isActive={true} />
+          );
+        })}
+      </svg>
+      {agents.map((agent, i) => {
+        const pos = positions[i];
+        if (!pos) return null;
+        return (
+          <div
+            key={agent.name}
+            style={{ position: 'absolute', left: pos.x, top: pos.y, transform: 'translate(-50%, -50%)' }}
+          >
+            <AgentNode
+              icon={agent.icon}
+              color={agent.color}
+              name={agent.name}
+              isActive={activeNodes.has(agent.name)}
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create `AgentNode` component to render floating agent icons
- create `AgentLink` component for animated SVG connections
- add `NeuralAgentMap` which uses these components and maps log events to active links

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856482f67288323b4cd0b837937c7b0