### PR TITLE
Implement neural agent dashboard

### DIFF
--- a/components/NeuralAgentMap.jsx
+++ b/components/NeuralAgentMap.jsx
@@ -1,0 +1,74 @@
+import React, { useEffect, useRef, useState } from 'react';
+import ForceGraph2D from 'react-force-graph-2d';
+import { motion } from 'framer-motion';
+import parseLogs from '../utils/parseAgentLogs.js';
+import styles from '../styles/AgentGraph.module.css';
+
+export default function NeuralAgentMap({ agents = [], logEvents = [] }) {
+  const [nodes, setNodes] = useState([]);
+  const [links, setLinks] = useState([]);
+  const graphRef = useRef();
+  const expireMs = 15000;
+
+  useEffect(() => {
+    setNodes(agents.map(id => ({ id, name: id })));
+  }, [agents]);
+
+  useEffect(() => {
+    if (logEvents.length) handleLogs(logEvents);
+  }, [logEvents]);
+
+  const handleLogs = events => {
+    const updates = parseLogs(events);
+    if (!updates.length) return;
+    setLinks(curr => {
+      const now = Date.now();
+      const next = [...curr];
+      updates.forEach(u => {
+        const idx = next.findIndex(l => l.source === u.from && l.target === u.to);
+        if (idx > -1) {
+          next[idx] = { ...next[idx], lastActive: now };
+        } else {
+          next.push({ source: u.from, target: u.to, lastActive: now });
+        }
+      });
+      return next;
+    });
+  };
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      const now = Date.now();
+      setLinks(ls => ls.filter(l => now - (l.lastActive || 0) < expireMs));
+    }, 3000);
+    return () => clearInterval(timer);
+  }, []);
+
+  const drawNode = (node, ctx, globalScale) => {
+    const fontSize = 12 / globalScale;
+    ctx.fillStyle = '#4f46e5';
+    ctx.beginPath();
+    ctx.arc(node.x, node.y, 6, 0, 2 * Math.PI, false);
+    ctx.fill();
+    ctx.font = `${fontSize}px sans-serif`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillStyle = '#fff';
+    ctx.fillText(node.name, node.x, node.y - 10);
+  };
+
+  return (
+    <motion.div className={`w-full h-full ${styles.container}`} initial={{ opacity: 0 }} animate={{ opacity: 1 }}>
+      <ForceGraph2D
+        ref={graphRef}
+        graphData={{ nodes, links }}
+        nodeCanvasObject={drawNode}
+        linkDirectionalParticles={2}
+        linkDirectionalParticleSpeed={() => 0.005}
+        linkDirectionalParticleWidth={() => 2}
+        linkColor={() => '#888'}
+        enableNodeDrag={false}
+      />
+    </motion.div>
+  );
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -10,7 +10,7 @@ import WelcomeOverlay from './WelcomeOverlay.jsx';
 import WelcomeExperience from './WelcomeExperience.jsx';
 import OnboardingOverlay from './OnboardingOverlay.jsx';
 import Gallery from './Gallery.jsx';
-import AdminDashboard from '../AdminDashboard.jsx';
+import Dashboard from '../pages/Dashboard.jsx';
 import FeedbackFab from './FeedbackFab.jsx';
 import ErrorBoundary from './ErrorBoundary.jsx';
 
@@ -56,7 +56,7 @@ function App() {
     } else if (isUseCases) {
       content = <UseCaseSelector />;
     } else if (isDashboard) {
-      content = <AdminDashboard />;
+      content = <Dashboard />;
     } else {
       content = (
         <>

--- a/pages/Dashboard.jsx
+++ b/pages/Dashboard.jsx
@@ -1,70 +1,76 @@
 import React, { useEffect, useState } from 'react';
-import { collection, query, orderBy, onSnapshot } from 'firebase/firestore';
 import { AnimatePresence } from 'framer-motion';
-import AgentSidebar from '../components/AgentSidebar.jsx';
-import RealTimeLogConsole from '../components/RealTimeLogConsole.jsx';
+import NeuralAgentMap from '../components/NeuralAgentMap.jsx';
 import StatusCard from '../components/StatusCard.jsx';
+import RealTimeLogConsole from '../components/RealTimeLogConsole.jsx';
+import AgentSidebar from '../components/AgentSidebar.jsx';
 import { useTheme } from '../context/ThemeContext.jsx';
-import { db } from '../frontend/src/firebase';
-import logDashboard from '../utils/logDashboard.js';
 
 export default function Dashboard() {
   const { theme, toggleTheme } = useTheme();
   const [agents, setAgents] = useState([]);
   const [collapsed, setCollapsed] = useState(false);
-  const [logs, setLogs] = useState({});
+  const [logEvents, setLogEvents] = useState([]);
 
   useEffect(() => {
-    fetch('/agents/agent-metadata.json')
-      .then(r => r.json())
-      .then(data => setAgents(Object.keys(data || {}).map(id => ({ id, ...data[id] }))))
-      .catch(() => setAgents([]));
+    const loadAgents = async () => {
+      try {
+        const res = await fetch('/api/agents');
+        const data = await res.json();
+        setAgents(data);
+      } catch {
+        setAgents(['insights-agent', 'swat-agent', 'data-agent']);
+      }
+    };
+    loadAgents();
   }, []);
 
   useEffect(() => {
-    const q = query(collection(db, 'logs'), orderBy('timestamp', 'desc'));
-    const unsub = onSnapshot(q, snap => {
-      const grouped = {};
-      snap.docs.forEach(d => {
-        const data = d.data();
-        const current = grouped[data.agent];
-        if (!current || data.timestamp > current.timestamp) {
-          grouped[data.agent] = data;
-        }
-      });
-      setLogs(grouped);
-    });
-    return unsub;
+    const loadLogs = async () => {
+      try {
+        const res = await fetch('/api/dashboard-logs');
+        const data = await res.json();
+        setLogEvents(Array.isArray(data) ? data : []);
+      } catch {
+        setLogEvents([]);
+      }
+    };
+    loadLogs();
   }, []);
 
-  const agentStates = agents.map(a => {
-    const log = logs[a.id];
+  const agentStates = agents.map(id => {
+    const log = logEvents.find(l => l.agent === id) || {};
     let status = 'idle';
-    if (log) {
+    if (log.timestamp) {
       const age = Date.now() - new Date(log.timestamp).getTime();
       status = log.error ? 'error' : age < 5 * 60 * 1000 ? 'running' : 'idle';
     }
-    return { ...a, status, log };
+    return { id, status, log };
   });
 
   const toggle = () => setCollapsed(c => !c);
 
   return (
-    <div className="min-h-screen flex bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
-      <AgentSidebar agents={agentStates} collapsed={collapsed} onToggle={toggle} onSelect={id => logDashboard('select_agent', { id })} />
-      <div className="flex-1 p-4 space-y-4">
-        <header className="flex justify-between items-center">
+    <div className="min-h-screen grid md:grid-cols-2 bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
+      <div className="p-4 space-y-4">
+        <AgentSidebar agents={agentStates} collapsed={collapsed} onToggle={toggle} />
+        <RealTimeLogConsole className="h-64" />
+      </div>
+      <div className="p-4 space-y-4">
+        <header className="flex justify-between items-center mb-4">
           <h1 className="text-2xl font-bold">Agent Dashboard</h1>
           <button onClick={toggleTheme} className="text-sm">Toggle {theme === 'dark' ? 'Light' : 'Dark'} Mode</button>
         </header>
-        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        <div className="grid gap-2 grid-cols-2 md:grid-cols-3">
           <AnimatePresence>
             {agentStates.map(a => (
               <StatusCard key={a.id} agent={a} />
             ))}
           </AnimatePresence>
         </div>
-        <RealTimeLogConsole className="h-64" />
+        <div className="h-[500px]">
+          <NeuralAgentMap agents={agents} logEvents={logEvents} />
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add `NeuralAgentMap` component for visualizing agent interactions
- update `pages/Dashboard.jsx` to fetch agents/logs and render the map with sidebar and console
- hook new dashboard into the front-end router

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68564842c030832394ea14b25ca353cb