### PR TITLE
Fix duplicate imports in Dashboard.jsx

### DIFF
--- a/pages/Dashboard.jsx
+++ b/pages/Dashboard.jsx
@@ -2,13 +2,8 @@ import React, { useEffect, useState } from 'react';
 import { AnimatePresence } from 'framer-motion';
 import NeuralAgentMap from '../components/NeuralAgentMap.jsx';
 import StatusCard from '../components/StatusCard.jsx';
-import React, { useEffect, useState } from 'react';
-import { AnimatePresence } from 'framer-motion';
-import NeuralAgentMap from '../components/NeuralAgentMap.jsx';
-import StatusCard from '../components/StatusCard.jsx';
 import RealTimeLogConsole from '../components/RealTimeLogConsole.jsx';
 import AgentSidebar from '../components/AgentSidebar.jsx';
-import { useTheme } from '../context/ThemeContext.jsx';
 import { useTheme } from '../context/ThemeContext.jsx';
 
 export default function Dashboard() {


### PR DESCRIPTION
## Summary
- remove repeated import statements from `pages/Dashboard.jsx`
- consolidate unique imports at the top of the file

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68564f1084a083239d6084ae4c0ed237