### PR TITLE
Fix minimal React vite entry point

### DIFF
--- a/src/Dashboard.jsx
+++ b/src/Dashboard.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function Dashboard() {
+  return <div>Dashboard Placeholder</div>;
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import Dashboard from '../pages/Dashboard.jsx';
+import Dashboard from './Dashboard.jsx';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>


### PR DESCRIPTION
## Summary
- add a simple Dashboard component
- update main.jsx to use the new component

## Testing
- `npm install`
- `npx vite --port 5174 --strictPort < /dev/null > /tmp/dev.log 2>&1 &`
- `curl -s http://localhost:5174 | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_685656f19fcc83238f28ba62f528735f