### PR TITLE
Add interactive dashboard

### DIFF
--- a/components/AgentDetailDrawer.jsx
+++ b/components/AgentDetailDrawer.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+
+export default function AgentDetailDrawer({ log, onClose }) {
+  const ts = log?.timestamp ? new Date(log.timestamp).toLocaleString() : '';
+  return (
+    <AnimatePresence>
+      {log && (
+        <motion.div className="fixed inset-0 z-50" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}>
+          <div className="absolute inset-0 bg-black/50" onClick={onClose}></div>
+          <motion.div
+            className="absolute right-0 top-0 h-full w-full sm:w-96 bg-white dark:bg-gray-800 shadow-xl overflow-y-auto p-4"
+            initial={{ x: '100%' }}
+            animate={{ x: 0 }}
+            exit={{ x: '100%' }}
+            transition={{ type: 'tween' }}
+          >
+            <button onClick={onClose} className="text-sm mb-4">
+              Close
+            </button>
+            <h2 className="text-lg font-bold mb-1">{log.agent}</h2>
+            <div className="text-xs opacity-80 mb-4">{ts}</div>
+            <pre className="whitespace-pre-wrap break-words text-sm mb-4">{log.output}</pre>
+            <button
+              onClick={() => navigator.clipboard.writeText(log.output || '')}
+              className="text-xs underline"
+            >
+              Copy
+            </button>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/components/AgentLogItem.jsx
+++ b/components/AgentLogItem.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import sanitize from '../utils/sanitize.js';
+
+export default function AgentLogItem({ log, onSelect }) {
+  const ts = log.timestamp ? new Date(log.timestamp).toLocaleString() : '';
+  const summary = sanitize(log.output || '').slice(0, 120);
+  const status = log.error ? 'Error' : 'Success';
+  return (
+    <motion.div
+      layout
+      onClick={() => onSelect(log)}
+      className="cursor-pointer p-2 hover:bg-gray-50 dark:hover:bg-gray-700"
+    >
+      <div className="flex justify-between text-sm font-medium">
+        <span>{log.agent}</span>
+        <span>{ts}</span>
+      </div>
+      <div className="text-xs mb-1">{summary}</div>
+      <div className="text-xs">
+        {log.error ? (
+          <span className="text-red-500">❌ {status}</span>
+        ) : (
+          <span className="text-green-500">✅ {status}</span>
+        )}
+      </div>
+    </motion.div>
+  );
+}

--- a/components/AgentLogList.jsx
+++ b/components/AgentLogList.jsx
@@ -1,0 +1,78 @@
+import React, { useEffect, useState } from 'react';
+import { collection, query, orderBy, limit, onSnapshot } from 'firebase/firestore';
+import { db } from '../frontend/src/firebase';
+import AgentLogItem from './AgentLogItem.jsx';
+
+export default function AgentLogList({ onSelect }) {
+  const [logs, setLogs] = useState([]);
+  const [agentFilter, setAgentFilter] = useState('');
+  const [startDate, setStartDate] = useState('');
+  const [endDate, setEndDate] = useState('');
+  const [errorsOnly, setErrorsOnly] = useState(false);
+
+  useEffect(() => {
+    try {
+      const q = query(collection(db, 'logs'), orderBy('timestamp', 'desc'), limit(100));
+      const unsub = onSnapshot(q, (snap) => {
+        setLogs(snap.docs.map((d) => ({ id: d.id, ...d.data() })));
+      });
+      return unsub;
+    } catch (err) {
+      console.warn('Firestore unavailable', err);
+      setLogs([]);
+    }
+  }, []);
+
+  const filtered = logs.filter((l) => {
+    if (agentFilter && !l.agent?.toLowerCase().includes(agentFilter.toLowerCase())) {
+      return false;
+    }
+    if (errorsOnly && !l.error) return false;
+    if (startDate && new Date(l.timestamp) < new Date(startDate)) return false;
+    if (endDate && new Date(l.timestamp) > new Date(endDate)) return false;
+    return true;
+  });
+
+  if (!filtered.length) {
+    return <div className="p-4 text-center">No agent activity yet.</div>;
+  }
+
+  return (
+    <div className="h-full flex flex-col">
+      <div className="flex flex-wrap gap-2 mb-2 text-sm">
+        <input
+          type="text"
+          value={agentFilter}
+          onChange={(e) => setAgentFilter(e.target.value)}
+          placeholder="Filter by agent"
+          className="border px-2 py-1 rounded"
+        />
+        <input
+          type="date"
+          value={startDate}
+          onChange={(e) => setStartDate(e.target.value)}
+          className="border px-2 py-1 rounded"
+        />
+        <input
+          type="date"
+          value={endDate}
+          onChange={(e) => setEndDate(e.target.value)}
+          className="border px-2 py-1 rounded"
+        />
+        <label className="flex items-center gap-1">
+          <input
+            type="checkbox"
+            checked={errorsOnly}
+            onChange={(e) => setErrorsOnly(e.target.checked)}
+          />
+          Errors only
+        </label>
+      </div>
+      <div className="overflow-y-auto flex-1 divide-y divide-gray-200 dark:divide-gray-700">
+        {filtered.map((log) => (
+          <AgentLogItem key={log.id} log={log} onSelect={onSelect} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/Sidebar.jsx
+++ b/components/Sidebar.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+export default function Sidebar({ items = [], current, onSelect }) {
+  return (
+    <aside className="w-40 bg-gray-200 dark:bg-gray-800 p-4 space-y-2 flex-shrink-0">
+      {items.map((item) => (
+        <button
+          key={item.id}
+          onClick={() => onSelect(item.id)}
+          className={`block w-full text-left px-2 py-1 rounded text-sm ${
+            current === item.id
+              ? 'bg-gray-300 dark:bg-gray-700'
+              : 'hover:bg-gray-300 dark:hover:bg-gray-700'
+          }`}
+        >
+          {item.label}
+        </button>
+      ))}
+    </aside>
+  );
+}


### PR DESCRIPTION
## Summary
- rework Dashboard.jsx into a two-column layout with sidebar and tabbed views
- add AgentLogList, AgentLogItem, Sidebar and AgentDetailDrawer components
- integrate Firestore with real-time updates
- show onboarding message and live status panel

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a057e35508323bacf581047cdaab7