### PR TITLE
Add agent library and onboarding

### DIFF
--- a/agents.json
+++ b/agents.json
@@ -1,0 +1,52 @@
+[
+  {
+    "id": "insights-agent",
+    "name": "Content Insights Agent",
+    "category": "CX / Marketing",
+    "summary": "Analyzes content engagement metrics to highlight optimization opportunities.",
+    "defaultInputs": {
+      "companyName": "Acme Corp",
+      "websiteUrl": "https://acme.com",
+      "email": "info@acme.com"
+    }
+  },
+  {
+    "id": "website-scanner-agent",
+    "name": "Website Scanner Agent",
+    "category": "Data Extraction",
+    "summary": "Fetches a website URL and extracts metadata and link structure.",
+    "defaultInputs": {
+      "url": "https://acme.com"
+    }
+  },
+  {
+    "id": "data-analyst-agent",
+    "name": "Data Analyst Agent",
+    "category": "Analytics",
+    "summary": "Aggregates agent outputs for statistics and correlations while flagging outliers.",
+    "defaultInputs": {
+      "agentOutputs": []
+    }
+  },
+  {
+    "id": "board-agent",
+    "name": "Strategy Board Agent",
+    "category": "Governance",
+    "summary": "Aggregates mentor metrics and logs to provide governance recommendations.",
+    "defaultInputs": {}
+  },
+  {
+    "id": "vercel-ops-agent",
+    "name": "Vercel Ops Agent",
+    "category": "DevOps",
+    "summary": "Validates Vercel config and reports deploy issues.",
+    "defaultInputs": {
+      "prNumber": 123,
+      "project": "demo",
+      "branch": "main",
+      "triggerDeploy": false,
+      "deploymentStatus": "",
+      "deploymentError": ""
+    }
+  }
+]

--- a/components/AgentDetailDrawer.jsx
+++ b/components/AgentDetailDrawer.jsx
@@ -3,6 +3,15 @@ import { AnimatePresence, motion } from 'framer-motion';
 
 export default function AgentDetailDrawer({ log, onClose }) {
   const ts = log?.timestamp ? new Date(log.timestamp).toLocaleString() : '';
+  const jsonData = JSON.stringify(
+    {
+      input: log?.input,
+      output: log?.output,
+      explanation: log?.explanation,
+    },
+    null,
+    2
+  );
   return (
     <AnimatePresence>
       {log && (
@@ -19,14 +28,40 @@ export default function AgentDetailDrawer({ log, onClose }) {
               Close
             </button>
             <h2 className="text-lg font-bold mb-1">{log.agent}</h2>
-            <div className="text-xs opacity-80 mb-4">{ts}</div>
-            <pre className="whitespace-pre-wrap break-words text-sm mb-4">{log.output}</pre>
-            <button
-              onClick={() => navigator.clipboard.writeText(log.output || '')}
-              className="text-xs underline"
-            >
-              Copy
-            </button>
+            <div className="text-xs opacity-80 mb-2">{ts}</div>
+            {log.input && (
+              <div className="mb-2 text-sm">
+                <div className="font-semibold mb-1">Input</div>
+                <pre className="whitespace-pre-wrap break-words bg-gray-50 dark:bg-gray-700 p-2 rounded text-xs">{JSON.stringify(log.input, null, 2)}</pre>
+              </div>
+            )}
+            {log.output && (
+              <div className="mb-2 text-sm">
+                <div className="font-semibold mb-1">Output</div>
+                <pre className="whitespace-pre-wrap break-words bg-gray-50 dark:bg-gray-700 p-2 rounded text-xs">{typeof log.output === 'string' ? log.output : JSON.stringify(log.output, null, 2)}</pre>
+              </div>
+            )}
+            {log.explanation && (
+              <div className="mb-2 text-sm">
+                <div className="font-semibold mb-1">Explanation</div>
+                <pre className="whitespace-pre-wrap break-words bg-gray-50 dark:bg-gray-700 p-2 rounded text-xs">{log.explanation}</pre>
+              </div>
+            )}
+            <div className="flex gap-4 mt-2">
+              <button
+                onClick={() => navigator.clipboard.writeText(jsonData)}
+                className="text-xs underline"
+              >
+                Copy JSON
+              </button>
+              <a
+                href={`data:application/json,${encodeURIComponent(jsonData)}`}
+                download={`${log.agent}-output.json`}
+                className="text-xs underline"
+              >
+                Download
+              </a>
+            </div>
           </motion.div>
         </motion.div>
       )}

--- a/components/OnboardingModal.jsx
+++ b/components/OnboardingModal.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+
+export default function OnboardingModal({ show, onClose }) {
+  return (
+    <AnimatePresence>
+      {show && (
+        <motion.div
+          className="fixed inset-0 z-50 flex items-center justify-center"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+        >
+          <div className="absolute inset-0 bg-black/50" onClick={onClose}></div>
+          <motion.div
+            className="relative bg-white dark:bg-gray-800 p-6 rounded-lg shadow-xl z-50 max-w-sm w-full text-center"
+            initial={{ scale: 0.9, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            exit={{ scale: 0.9, opacity: 0 }}
+          >
+            <h2 className="text-xl font-semibold mb-2">Welcome to AI Agent Systems</h2>
+            <p className="mb-4 text-sm">Get started by running a sample agent or browsing the library.</p>
+            <div className="space-y-2">
+              <a href="/agents" className="block bg-blue-600 text-white py-2 rounded">Run a sample agent</a>
+              <a href="/agents" className="block bg-green-600 text-white py-2 rounded">View agent library</a>
+              <a href="/billing" className="block bg-purple-600 text-white py-2 rounded">Connect billing</a>
+            </div>
+            <button onClick={onClose} className="mt-4 text-sm text-gray-500">Close</button>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -10,6 +10,7 @@ import WelcomeOverlay from './WelcomeOverlay.jsx';
 import WelcomeExperience from './WelcomeExperience.jsx';
 import OnboardingOverlay from './OnboardingOverlay.jsx';
 import Gallery from './Gallery.jsx';
+import AgentsPage from '../../pages/Agents.jsx';
 import Dashboard from '../../pages/Dashboard.jsx';
 import FeedbackFab from './FeedbackFab.jsx';
 import ErrorBoundary from './ErrorBoundary.jsx';
@@ -20,6 +21,7 @@ function App() {
   try {
     const isDemo = path.startsWith('/demo');
     const isGallery = path.startsWith('/gallery');
+    const isAgents = path.startsWith('/agents');
     const isUseCases = path.startsWith('/use-cases');
     const isDashboard = path.startsWith('/dashboard');
 
@@ -53,6 +55,8 @@ function App() {
       content = <DemoPage />;
     } else if (isGallery) {
       content = <Gallery />;
+    } else if (isAgents) {
+      content = <AgentsPage />;
     } else if (isUseCases) {
       content = <UseCaseSelector />;
     } else if (isDashboard) {

--- a/pages/Agents.jsx
+++ b/pages/Agents.jsx
@@ -1,0 +1,77 @@
+import React, { useEffect, useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+
+export default function AgentsPage() {
+  const [agents, setAgents] = useState([]);
+  const [selected, setSelected] = useState(null);
+  const [form, setForm] = useState({});
+  const [output, setOutput] = useState(null);
+
+  useEffect(() => {
+    fetch('/agents.json')
+      .then(r => r.json())
+      .then(setAgents)
+      .catch(() => setAgents([]));
+  }, []);
+
+  const open = (agent) => {
+    setSelected(agent);
+    setForm({ ...(agent.defaultInputs || {}) });
+    setOutput(null);
+  };
+
+  const run = async () => {
+    if (!selected) return;
+    const res = await fetch('/run-agent', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ agent: selected.id, input: form })
+    });
+    const data = await res.json();
+    setOutput(data.result || data.response || data.error);
+  };
+
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold mb-4">Agent Library</h1>
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {agents.map(a => (
+          <div key={a.id} className="border rounded p-4 space-y-2">
+            <div className="font-semibold">{a.name}</div>
+            <div className="text-xs text-gray-500">{a.category}</div>
+            <p className="text-sm">{a.summary}</p>
+            <button onClick={() => open(a)} className="text-sm text-blue-600 underline">
+              Run Now
+            </button>
+          </div>
+        ))}
+      </div>
+
+      <AnimatePresence>
+        {selected && (
+          <motion.div className="fixed inset-0 z-50 flex items-center justify-center" initial={{opacity:0}} animate={{opacity:1}} exit={{opacity:0}}>
+            <div className="absolute inset-0 bg-black/50" onClick={() => setSelected(null)}></div>
+            <motion.div className="relative bg-white dark:bg-gray-800 p-6 rounded-lg shadow-xl z-50 max-w-sm w-full" initial={{scale:0.9, opacity:0}} animate={{scale:1, opacity:1}} exit={{scale:0.9, opacity:0}}>
+              <h2 className="font-semibold mb-2">{selected.name}</h2>
+              {Object.keys(form).map(key => (
+                <input
+                  key={key}
+                  className="border w-full p-2 text-sm mb-2 rounded"
+                  value={form[key]}
+                  onChange={e => setForm({ ...form, [key]: e.target.value })}
+                />
+              ))}
+              <div className="flex gap-2 mt-2">
+                <button onClick={run} className="bg-blue-600 text-white px-3 py-1 rounded text-sm">Run</button>
+                <button onClick={() => setSelected(null)} className="text-sm underline">Close</button>
+              </div>
+              {output && (
+                <pre className="mt-4 text-xs bg-gray-100 dark:bg-gray-700 p-2 rounded whitespace-pre-wrap">{typeof output === 'string' ? output : JSON.stringify(output, null, 2)}</pre>
+              )}
+            </motion.div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/pages/Dashboard.jsx
+++ b/pages/Dashboard.jsx
@@ -3,6 +3,7 @@ import { motion } from 'framer-motion';
 import Sidebar from '../components/Sidebar.jsx';
 import AgentLogList from '../components/AgentLogList.jsx';
 import AgentDetailDrawer from '../components/AgentDetailDrawer.jsx';
+import OnboardingModal from '../components/OnboardingModal.jsx';
 import { useTheme } from '../context/ThemeContext.jsx';
 
 function AgentStatusPanel({ agents = [] }) {
@@ -34,12 +35,24 @@ export default function Dashboard() {
   const [selectedLog, setSelectedLog] = useState(null);
   const [agents, setAgents] = useState([]);
   const [firstVisit, setFirstVisit] = useState(false);
+  const [showOnboarding, setShowOnboarding] = useState(false);
 
   useEffect(() => {
     if (!localStorage.getItem('dashboardVisited')) {
       setFirstVisit(true);
       localStorage.setItem('dashboardVisited', 'true');
     }
+  }, []);
+
+  useEffect(() => {
+    fetch('/logs')
+      .then((r) => r.json())
+      .then((data) => {
+        if (!data.length && !localStorage.getItem('hasSeenOnboarding')) {
+          setShowOnboarding(true);
+        }
+      })
+      .catch(() => {});
   }, []);
 
   useEffect(() => {
@@ -83,6 +96,13 @@ export default function Dashboard() {
         </main>
       </div>
       <AgentDetailDrawer log={selectedLog} onClose={() => setSelectedLog(null)} />
+      <OnboardingModal
+        show={showOnboarding}
+        onClose={() => {
+          localStorage.setItem('hasSeenOnboarding', 'true');
+          setShowOnboarding(false);
+        }}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- populate agent catalog in new `agents.json`
- add onboarding modal for first-time users
- enhance agent detail drawer to show inputs and outputs
- implement `/agents` page to browse and run agents
- route `/agents` in front-end entry

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a0fca9f388323b484058ca233e7c1