### PR TITLE
Implement plan & trial enforcement

### DIFF
--- a/functions/middleware/billing.js
+++ b/functions/middleware/billing.js
@@ -1,0 +1,94 @@
+const { admin, db } = require('../../firebase');
+
+const FREE_LIMIT = 3;
+const TRIAL_DAYS = 14;
+
+function billingRef(uid) {
+  return db
+    .collection('users')
+    .doc(uid)
+    .collection('billingStatus')
+    .doc('current');
+}
+
+async function ensureBilling(uid) {
+  const ref = billingRef(uid);
+  const snap = await ref.get();
+  if (!snap.exists) {
+    const data = {
+      plan: 'free',
+      trialStartedAt: new Date().toISOString(),
+      usage: { totalRuns: 0, agents: {} }
+    };
+    await ref.set(data);
+    return data;
+  }
+  return snap.data();
+}
+
+async function getBillingStatus(uid) {
+  const status = await ensureBilling(uid);
+  if (status.trialStartedAt) {
+    const trialDate = new Date(status.trialStartedAt);
+    status.daysRemaining = TRIAL_DAYS - Math.floor((Date.now() - trialDate.getTime()) / 86400000);
+  } else {
+    status.daysRemaining = null;
+  }
+  return status;
+}
+
+async function incrementUsage(uid, agent) {
+  const ref = billingRef(uid);
+  const updates = {
+    'usage.totalRuns': admin.firestore.FieldValue.increment(1),
+    [`usage.agents.${agent}`]: admin.firestore.FieldValue.increment(1)
+  };
+  await ref.set(updates, { merge: true });
+}
+
+async function verifyUser(req) {
+  const header = req.headers.authorization || '';
+  const token = header.startsWith('Bearer ') ? header.slice(7) : null;
+  if (!token) return null;
+  try {
+    const decoded = await admin.auth().verifyIdToken(token);
+    return decoded.uid;
+  } catch {
+    return null;
+  }
+}
+
+async function billingMiddleware(req, res, next) {
+  const uid = await verifyUser(req);
+  if (!uid) return res.status(401).json({ error: 'Unauthorized' });
+  req.uid = uid;
+  const status = await getBillingStatus(uid);
+  req.billing = status;
+
+  const plan = status.plan || 'free';
+  const runs = status.usage?.totalRuns || 0;
+  const daysRemaining = status.daysRemaining;
+
+  if (status.trialStartedAt && daysRemaining < 0 && plan !== 'pro') {
+    return res
+      .status(402)
+      .json({ error: 'trial_expired', message: 'Trial expired. Upgrade required.' });
+  }
+
+  if (plan !== 'pro' && runs >= FREE_LIMIT) {
+    return res
+      .status(402)
+      .json({ error: 'upgrade', message: 'Plan limit reached. Upgrade required.' });
+  }
+
+  req.billing.daysRemaining = daysRemaining;
+  next();
+}
+
+module.exports = {
+  billingMiddleware,
+  getBillingStatus,
+  incrementUsage,
+  FREE_LIMIT,
+  TRIAL_DAYS
+};

--- a/pages/Dashboard.jsx
+++ b/pages/Dashboard.jsx
@@ -4,6 +4,7 @@ import Sidebar from '../components/Sidebar.jsx';
 import AgentLogList from '../components/AgentLogList.jsx';
 import AgentDetailDrawer from '../components/AgentDetailDrawer.jsx';
 import OnboardingModal from '../components/OnboardingModal.jsx';
+import BillingPanel from '../frontend/client/BillingPanel.jsx';
 import { useTheme } from '../context/ThemeContext.jsx';
 
 function AgentStatusPanel({ agents = [] }) {
@@ -66,6 +67,7 @@ export default function Dashboard() {
     { id: 'logs', label: 'Agent Logs' },
     { id: 'reports', label: 'Reports' },
     { id: 'status', label: 'Live Status' },
+    { id: 'billing', label: 'Billing' },
   ];
 
   const runningAgents = agents.map((a) => ({
@@ -93,6 +95,11 @@ export default function Dashboard() {
           {view === 'logs' && <AgentLogList onSelect={setSelectedLog} />}
           {view === 'status' && <AgentStatusPanel agents={runningAgents} />}
           {view === 'reports' && <div className="p-4">Reports coming soon...</div>}
+          {view === 'billing' && (
+            <div className="p-4">
+              <BillingPanel />
+            </div>
+          )}
         </main>
       </div>
       <AgentDetailDrawer log={selectedLog} onClose={() => setSelectedLog(null)} />


### PR DESCRIPTION
## Summary
- enforce plan limits via new billing middleware
- store trial start and billing data on signup
- add usage tracking per agent
- surface billing dashboard with trial warnings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a125955b483239c2aae3536576098