### PR TITLE
Add flow result sharing & download

### DIFF
--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -12,6 +12,7 @@ import OnboardingOverlay from './OnboardingOverlay.jsx';
 import Gallery from './Gallery.jsx';
 import AgentsPage from '../../pages/Agents.jsx';
 import Dashboard from '../../pages/Dashboard.jsx';
+import FlowViewPage from '../../pages/flows/[flowId]/view.jsx';
 import FeedbackFab from './FeedbackFab.jsx';
 import ErrorBoundary from './ErrorBoundary.jsx';
 
@@ -24,6 +25,8 @@ function App() {
     const isAgents = path.startsWith('/agents');
     const isUseCases = path.startsWith('/use-cases');
     const isDashboard = path.startsWith('/dashboard');
+    const flowViewMatch = path.match(/^\/flows\/([^/]+)\/view/);
+    const isFlowView = !!flowViewMatch;
 
     const [onboarded, setOnboarded] = useState(
       localStorage.getItem('onboarded') === 'true'
@@ -61,6 +64,12 @@ function App() {
       content = <UseCaseSelector />;
     } else if (isDashboard) {
       content = <Dashboard />;
+    } else if (isFlowView) {
+      let decoded = flowViewMatch[1];
+      try {
+        decoded = atob(decodeURIComponent(decoded));
+      } catch {}
+      content = <FlowViewPage flowId={decoded} />;
     } else {
       content = (
         <>

--- a/pages/flows/[flowId]/view.jsx
+++ b/pages/flows/[flowId]/view.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import FlowVisualizer from '../../../components/FlowVisualizer.jsx';
+
+export default function FlowViewPage({ flowId }) {
+  return (
+    <div className="p-4">
+      <FlowVisualizer flowId={flowId} />
+    </div>
+  );
+}

--- a/utils/exportFlowResult.js
+++ b/utils/exportFlowResult.js
@@ -1,0 +1,16 @@
+export default function exportFlowResult(flowId, config, logs = {}) {
+  if (!config) return null;
+  const steps = config.steps.map((step, idx) => {
+    const entry = logs[step.id] || {};
+    return {
+      order: idx + 1,
+      agent: step.agent,
+      timestamp: entry.timestamp || null,
+      input: entry.input,
+      output: entry.output,
+      explanation: entry.explanation,
+    };
+  });
+  const input = steps[0]?.input || {};
+  return { flowId, input, steps };
+}


### PR DESCRIPTION
## Summary
- add FlowVisualizer export utilities
- show download/share buttons when flows complete
- support read-only flow viewer route

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a19e854848323b764bdde38e201d7