### PR TITLE
Add dashboard flow and agent usage cards

### DIFF
--- a/components/AgentUsageCard.jsx
+++ b/components/AgentUsageCard.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+export default function AgentUsageCard({ usage = {} }) {
+  const entries = Object.entries(usage)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 5);
+  if (!entries.length) {
+    return (
+      <div className="p-4 border rounded">No agent usage yet.</div>
+    );
+  }
+  return (
+    <div className="p-4 border rounded">
+      <h2 className="font-semibold mb-2">Top Used Agents</h2>
+      <ul className="space-y-1 text-sm">
+        {entries.map(([name, count]) => (
+          <li key={name} className="flex justify-between">
+            <span>{name}</span>
+            <span className="font-medium">{count}x</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/components/FlowStatusBadge.jsx
+++ b/components/FlowStatusBadge.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+const styles = {
+  completed: 'bg-green-200 text-green-800',
+  running: 'bg-yellow-200 text-yellow-800',
+  failed: 'bg-red-200 text-red-800',
+};
+
+export default function FlowStatusBadge({ status = 'running' }) {
+  let label = 'Running';
+  let icon = '⏳';
+  let key = 'running';
+  if (status === 'completed' || status === 'complete') {
+    label = 'Completed';
+    icon = '✅';
+    key = 'completed';
+  } else if (status === 'failed' || status === 'error') {
+    label = 'Failed';
+    icon = '❌';
+    key = 'failed';
+  }
+  return (
+    <span className={`text-xs font-medium px-2 py-1 rounded ${styles[key]}`}> 
+      {icon} {label}
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary
- show recent flows and agent usage on the dashboard
- add FlowStatusBadge and AgentUsageCard components for reuse
- highlight trial period remaining if applicable

## Testing
- `npm run lint` *(fails: no-unused-vars and other issues)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a19e9f8c48323ab22dfdebfa2e371