### PR TITLE
Connect frontend with website-analysis flow

### DIFF
--- a/frontend/src/Sandbox.jsx
+++ b/frontend/src/Sandbox.jsx
@@ -5,6 +5,7 @@ export default function Sandbox() {
   const [flows, setFlows] = useState([]);
   const [flowId, setFlowId] = useState('');
   const [result, setResult] = useState(null);
+  const [websiteUrl, setWebsiteUrl] = useState('');
 
   useEffect(() => {
     fetch('/flows')
@@ -18,14 +19,14 @@ export default function Sandbox() {
   }, [flows, flowId]);
 
   const run = async () => {
-    if (!flowId) return;
-    const res = await fetch('/run-flow', {
+    if (!flowId || !websiteUrl) return;
+    const encoded = btoa(encodeURIComponent(websiteUrl));
+    await fetch('/run-flow', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ flowId, userId: 'dev-sandbox' })
-    });
-    const data = await res.json();
-    setResult(data);
+      body: JSON.stringify({ flowId: encoded, userId: 'dev-sandbox' })
+    }).catch(() => {});
+    window.location.href = `/flows/${encodeURIComponent(encoded)}/view`;
   };
 
   return (
@@ -43,6 +44,13 @@ export default function Sandbox() {
             </option>
           ))}
         </select>
+        <input
+          type="text"
+          value={websiteUrl}
+          onChange={e => setWebsiteUrl(e.target.value)}
+          placeholder="Website URL"
+          className="p-2 rounded text-black flex-1"
+        />
         <button onClick={run} className="bg-blue-600 text-white px-3 py-1 rounded">
           Run Test
         </button>

--- a/functions/index.js
+++ b/functions/index.js
@@ -1512,10 +1512,16 @@ if (process.env.NODE_ENV !== 'production') {
   });
 
   app.post('/run-flow', async (req, res) => {
-    const { flowId = '', userId = 'test-user', input = {} } = req.body || {};
+    const { flowId = '', userId = 'test-user' } = req.body || {};
     if (!flowId) return res.status(400).json({ error: 'flowId required' });
+    let url = '';
     try {
-      const result = await runAgentFlow(input, flowId, { userId });
+      url = decodeURIComponent(Buffer.from(flowId, 'base64').toString('utf8'));
+    } catch {
+      return res.status(400).json({ error: 'invalid flowId' });
+    }
+    try {
+      const result = await runAgentFlow(url, url, { userId, configId: 'website-analysis' });
       res.json(result);
     } catch (err) {
       res.status(500).json({ error: err.message });

--- a/pages/FlowViewPage.jsx
+++ b/pages/FlowViewPage.jsx
@@ -4,7 +4,7 @@ import FlowVisualizer from '../components/FlowVisualizer.jsx';
 export default function FlowViewPage({ flowId }) {
   return (
     <div className="p-4">
-      <FlowVisualizer flowId={flowId} />
+      <FlowVisualizer flowId="website-analysis" runId={flowId} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add website URL input to Sandbox and redirect to encoded flow view
- show flow logs for the website-analysis config
- support runId and failure display in `FlowVisualizer`
- run website-analysis pipeline in `agentFlowEngine` and log steps
- decode encoded flowId in `/run-flow` route

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a257031b88323ab45471907f5500e