### PR TITLE
Integrate frontend billing gate and flow launcher

### DIFF
--- a/frontend/src/LandingPage.jsx
+++ b/frontend/src/LandingPage.jsx
@@ -23,6 +23,7 @@ const LandingPage = () => {
   const [emailSent, setEmailSent] = useState(false);
   const [logMessages, setLogMessages] = useState([]);
   const [registeredAgents, setRegisteredAgents] = useState([]);
+  const [landingUrl, setLandingUrl] = useState('');
 
   useEffect(() => {
     const fetchAgents = async () => {
@@ -113,6 +114,20 @@ const LandingPage = () => {
     setStepStatus(analysisSteps.map((_, i) => (i === 0 ? 'active' : 'pending')));
   };
 
+  const handleFlowSubmit = async (e) => {
+    e.preventDefault();
+    if (!landingUrl) return;
+    const encoded = btoa(encodeURIComponent(landingUrl));
+    try {
+      await fetch('/run-flow', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ flowId: encoded })
+      });
+    } catch {}
+    window.location.href = `/flows/${encodeURIComponent(encoded)}/view`;
+  };
+
   const subscribeToLogs = () => {
     const q = query(collection(db, 'logs'), orderBy('timestamp'));
     return onSnapshot(q, snap => {
@@ -166,6 +181,24 @@ const LandingPage = () => {
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900">
       <div className="relative z-10">
+        <section className="py-20 text-center">
+          <h1 className="text-4xl font-bold text-white mb-4">Analyze Your Website</h1>
+          <form onSubmit={handleFlowSubmit} className="max-w-xl mx-auto flex">
+            <input
+              type="text"
+              value={landingUrl}
+              onChange={(e) => setLandingUrl(e.target.value)}
+              placeholder="https://example.com"
+              className="flex-1 p-2 rounded-l text-black"
+            />
+            <button
+              type="submit"
+              className="bg-blue-600 hover:bg-blue-700 text-white px-4 rounded-r"
+            >
+              Analyze
+            </button>
+          </form>
+        </section>
         <section className="px-6 py-20 text-center">
           <div className="max-w-4xl mx-auto">
             <h1 className="text-5xl font-bold text-white mb-6">Start Your AI Analysis</h1>

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -3,6 +3,13 @@ import { createRoot } from 'react-dom/client';
 import { AnimatePresence } from 'framer-motion';
 import './index.css';
 
+const query = new URLSearchParams(window.location.search);
+const pending = localStorage.getItem('pendingFlowToken');
+if (query.get('success') === '1' && pending) {
+  localStorage.removeItem('pendingFlowToken');
+  window.location.replace(`/flows/${encodeURIComponent(pending)}/view`);
+}
+
 import LandingPage from './LandingPage.jsx';
 import DevToolsPanel from './DevToolsPanel.jsx';
 import DemoPage from './DemoPage.jsx';

--- a/functions/index.js
+++ b/functions/index.js
@@ -1511,7 +1511,7 @@ if (process.env.NODE_ENV !== 'production') {
     res.json(files);
   });
 
-  app.post('/run-flow', async (req, res) => {
+  app.post('/run-flow', billingMiddleware, async (req, res) => {
     const { flowId = '', userId = 'test-user' } = req.body || {};
     if (!flowId) return res.status(400).json({ error: 'flowId required' });
     let url = '';

--- a/functions/middleware/billing.js
+++ b/functions/middleware/billing.js
@@ -72,13 +72,21 @@ async function billingMiddleware(req, res, next) {
   if (status.trialStartedAt && daysRemaining < 0 && plan !== 'pro') {
     return res
       .status(402)
-      .json({ error: 'trial_expired', message: 'Trial expired. Upgrade required.' });
+      .json({
+        error: 'trial_expired',
+        message: 'Trial expired. Upgrade required.',
+        redirect: '/create-checkout-session'
+      });
   }
 
   if (plan !== 'pro' && runs >= FREE_LIMIT) {
     return res
       .status(402)
-      .json({ error: 'upgrade', message: 'Plan limit reached. Upgrade required.' });
+      .json({
+        error: 'upgrade',
+        message: 'Plan limit reached. Upgrade required.',
+        redirect: '/create-checkout-session'
+      });
   }
 
   req.billing.daysRemaining = daysRemaining;

--- a/pages/FlowViewPage.jsx
+++ b/pages/FlowViewPage.jsx
@@ -1,7 +1,44 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import FlowVisualizer from '../components/FlowVisualizer.jsx';
 
 export default function FlowViewPage({ flowId }) {
+  useEffect(() => {
+    const checkBilling = async () => {
+      try {
+        const res = await fetch('/billing/info', {
+          headers: {
+            Authorization: `Bearer ${localStorage.getItem('token') || ''}`
+          }
+        });
+        const data = await res.json();
+        const remaining =
+          data.plan === 'pro'
+            ? Infinity
+            : 3 - ((data.usage?.totalRuns || 0));
+        const expired =
+          data.daysRemaining !== null && data.daysRemaining < 0;
+        if (expired || remaining <= 0) {
+          localStorage.setItem(
+            'pendingFlowToken',
+            btoa(encodeURIComponent(flowId))
+          );
+          const r = await fetch('/create-checkout-session', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              Authorization: `Bearer ${localStorage.getItem('token') || ''}`
+            },
+            body: JSON.stringify({})
+          });
+          const ck = await r.json();
+          if (ck.url) window.location.href = ck.url;
+        }
+      } catch (err) {
+        console.error('Billing check failed', err);
+      }
+    };
+    checkBilling();
+  }, [flowId]);
   return (
     <div className="p-4">
       <FlowVisualizer flowId="website-analysis" runId={flowId} />


### PR DESCRIPTION
## Summary
- add landing page CTA form to launch flows
- gate flow view behind billing check
- store pending flow tokens for post-checkout redirect
- expose redirect info in billing middleware
- protect `/run-flow` endpoint with billing middleware

## Testing
- `npm test`
- `npm run lint` *(fails: vision-guard-agent.js no-unused-vars, analytics.js no-undef, db.js no-unused-vars, functions/index.js no-unused-vars, scripts lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_685a2819795c8323b22734ffc73111f5