### PR TITLE
Fix FlowViewPage build path

### DIFF
--- a/frontend/FlowVisualizer.jsx
+++ b/frontend/FlowVisualizer.jsx
@@ -5,7 +5,7 @@ import { motion } from 'framer-motion';
 import { Loader2, CheckCircle, AlertTriangle, Clock } from 'lucide-react';
 import useAgentStepStatus from '../hooks/useAgentStepStatus.js';
 import loadFlowConfig from '../utils/loadFlowConfig.js';
-import AgentDetailDrawer from './AgentDetailDrawer.jsx';
+import AgentDetailDrawer from '../components/AgentDetailDrawer.jsx';
 import exportFlowResult from '../utils/exportFlowResult.js';
 
 const statusStyles = {

--- a/frontend/pages/FlowViewPage.jsx
+++ b/frontend/pages/FlowViewPage.jsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useState } from 'react';
-import FlowVisualizer from '../components/FlowVisualizer.jsx';
+import FlowVisualizer from '../FlowVisualizer.jsx';
 import { doc, onSnapshot } from 'firebase/firestore';
-import { db } from '../frontend/src/firebase.js';
-import loadFlowConfig from '../utils/loadFlowConfig.js';
+import { db } from '../src/firebase.js';
+import loadFlowConfig from '../../utils/loadFlowConfig.js';
 
 export default function FlowViewPage({ flowId }) {
   const [complete, setComplete] = useState(false);

--- a/frontend/src/Sandbox.jsx
+++ b/frontend/src/Sandbox.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import FlowVisualizer from '../../components/FlowVisualizer.jsx';
+import FlowVisualizer from '../FlowVisualizer.jsx';
 
 export default function Sandbox() {
   const [flows, setFlows] = useState([]);

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -20,7 +20,7 @@ import OnboardingOverlay from './OnboardingOverlay.jsx';
 import Gallery from './Gallery.jsx';
 import AgentsPage from '../../pages/Agents.jsx';
 import Dashboard from '../../pages/Dashboard.jsx';
-import FlowViewPage from '../../pages/FlowViewPage.jsx';
+import FlowViewPage from '../pages/FlowViewPage.jsx';
 import Sandbox from './Sandbox.jsx';
 import FeedbackFab from './FeedbackFab.jsx';
 import ErrorBoundary from './ErrorBoundary.jsx';


### PR DESCRIPTION
## Summary
- move `FlowViewPage.jsx` and `FlowVisualizer.jsx` into `frontend`
- update imports for moved files

## Testing
- `npm run build`
- `(cd frontend && npm run build)`

------
https://chatgpt.com/codex/tasks/task_e_685a2ed3d0008323a740080913befe39