### PR TITLE
Move AgentLogList to frontend, fix firebase imports

### DIFF
--- a/components/RealTimeLogConsole.jsx
+++ b/components/RealTimeLogConsole.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { collection, query, orderBy, limit, onSnapshot } from 'firebase/firestore';
 import { AnimatePresence, motion } from 'framer-motion';
-import { db } from '../frontend/src/firebase';
+import { db } from '../frontend/src/firebase.js';
 import sanitize from '../utils/sanitize.js';
 
 export default function RealTimeLogConsole({ className = '' }) {

--- a/frontend/components/AgentLogList.jsx
+++ b/frontend/components/AgentLogList.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { collection, query, orderBy, limit, onSnapshot } from 'firebase/firestore';
-import { db } from '../frontend/src/firebase';
-import AgentLogItem from './AgentLogItem.jsx';
+import { db } from '../src/firebase.js';
+import AgentLogItem from '../../components/AgentLogItem.jsx';
 
 export default function AgentLogList({ onSelect }) {
   const [logs, setLogs] = useState([]);

--- a/frontend/pages/Dashboard.jsx
+++ b/frontend/pages/Dashboard.jsx
@@ -11,7 +11,7 @@ import {
   getDoc,
 } from 'firebase/firestore';
 import Sidebar from '../../components/Sidebar.jsx';
-import AgentLogList from '../../components/AgentLogList.jsx';
+import AgentLogList from '../components/AgentLogList.jsx';
 import AgentDetailDrawer from '../../components/AgentDetailDrawer.jsx';
 import OnboardingModal from '../../components/OnboardingModal.jsx';
 import BillingPanel from '../client/BillingPanel.jsx';


### PR DESCRIPTION
## Summary
- move `AgentLogList.jsx` under `frontend/components`
- update imports in `AgentLogList` and dashboard
- explicitly import firebase module with extension

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685a378d764c8323942593769061ac0e