### PR TITLE
Fix firebase paths and add ssr guards

### DIFF
--- a/frontend/components/RealTimeLogConsole.jsx
+++ b/frontend/components/RealTimeLogConsole.jsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import { collection, query, orderBy, limit, onSnapshot } from 'firebase/firestore';
 import { AnimatePresence, motion } from 'framer-motion';
-import { db } from '../frontend/src/firebase.js';
-import sanitize from '../utils/sanitize.js';
+import { db } from '../src/firebase.js';
+import sanitize from '../../utils/sanitize.js';
 
 export default function RealTimeLogConsole({ className = '' }) {
   const [logs, setLogs] = useState([]);

--- a/frontend/pages/FlowViewPage.jsx
+++ b/frontend/pages/FlowViewPage.jsx
@@ -32,7 +32,9 @@ export default function FlowViewPage({ flowId }) {
             body: JSON.stringify({})
           });
           const ck = await r.json();
-          if (ck.url) window.location.href = ck.url;
+          if (ck.url && typeof window !== 'undefined') {
+            window.location.href = ck.url;
+          }
         }
       } catch (err) {
         console.error('Billing check failed', err);

--- a/frontend/pages/Welcome.jsx
+++ b/frontend/pages/Welcome.jsx
@@ -90,7 +90,9 @@ const Welcome = () => {
     e.preventDefault();
     const data = { company, url, email };
     localStorage.setItem('onboarding', JSON.stringify(data));
-    window.location.href = '/dashboard';
+    if (typeof window !== 'undefined') {
+      window.location.href = '/dashboard';
+    }
   };
 
   return (

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -20,6 +20,16 @@ const indexHtml = (() => {
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, 'src'),
+      '~components': resolve(__dirname, 'components'),
+      '~firebase': resolve(__dirname, 'src/firebase.js'),
+    },
+  },
+  ssr: {
+    noExternal: ['firebase'],
+  },
   build: {
     outDir: 'build',
     emptyOutDir: true,


### PR DESCRIPTION
## Summary
- guard client-only navigation with `typeof window !== 'undefined'`
- move `RealTimeLogConsole` into frontend components and fix imports
- alias firebase in Vite config for SSR safety

## Testing
- `npm test`
- `npm run lint` *(fails: no-unused-vars in functions and scripts)*
- `cd frontend && npm run build` *(fails: Cannot find module 'tailwindcss')*

------
https://chatgpt.com/codex/tasks/task_e_685a38dae438832380201cb6eab51b37