### PR TITLE
Add react-router deps to root

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-router": "^7.6.2",
+        "react-router-dom": "^7.6.2",
         "reactflow": "^11.11.4",
         "stripe": "^14.21.0"
       },
@@ -7237,6 +7238,22 @@
         "react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.6.2.tgz",
+      "integrity": "sha512-Q8zb6VlTbdYKK5JJBLQEN06oTUa/RAbG/oQS1auK1I0TbJOXktqm+QENEVJU6QvWynlXPRBXI3fiOQcSEA78rA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/react-router/node_modules/cookie": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.6.2",
+    "react-router-dom": "^7.6.2",
     "reactflow": "^11.11.4",
     "stripe": "^14.21.0"
   },


### PR DESCRIPTION
## Summary
- add `react-router-dom` dependency to root `package.json`
- run `npm install` to update `package-lock.json`

## Testing
- `npm install`
- `npm install` in `frontend`
- `npm run build` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_685a4365f56c832398fe7f4af59a2011