### PR TITLE
Add Agent log dashboard component

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,11 @@
+import AgentDashboard from './components/AgentDashboard';
+
+function App() {
+  return (
+    <div className="min-h-screen bg-gray-100 p-6">
+      <h1 className="text-3xl font-bold">AI Agent Systems</h1>
+      <AgentDashboard />
+    </div>
+  );
+}
+export default App;

--- a/src/components/AgentDashboard.jsx
+++ b/src/components/AgentDashboard.jsx
@@ -1,0 +1,18 @@
+import { useEffect, useState } from 'react';
+
+export default function AgentDashboard() {
+  const [log, setLog] = useState('');
+
+  useEffect(() => {
+    fetch('/logs/learning.log')
+      .then(res => res.text())
+      .then(data => setLog(data));
+  }, []);
+
+  return (
+    <div className="p-4">
+      <h2 className="text-xl font-bold">Agent Log Output</h2>
+      <pre className="bg-black text-green-400 p-2 mt-2">{log}</pre>
+    </div>
+  );
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import Dashboard from './Dashboard.jsx';
+import App from './App.jsx';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <Dashboard />
+    <App />
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- add AgentDashboard component to display backend logs
- wire up new component in a simple App

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a4fa8655c8323bcb98088afc4c34b