### PR TITLE
Add live log viewer to dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ logs/*
 !logs/system-audit.json
 !logs/dashboard.json
 *.log
+!public/logs/learning.log
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*

--- a/public/logs/learning.log
+++ b/public/logs/learning.log
@@ -1,0 +1,1 @@
+Sample learning log

--- a/src/components/AgentDashboard.jsx
+++ b/src/components/AgentDashboard.jsx
@@ -4,15 +4,23 @@ export default function AgentDashboard() {
   const [log, setLog] = useState('');
 
   useEffect(() => {
-    fetch('/logs/learning.log')
-      .then(res => res.text())
-      .then(data => setLog(data));
+    const fetchLog = () => {
+      fetch('/logs/learning.log')
+        .then(res => res.text())
+        .then(data => setLog(data));
+    };
+
+    fetchLog();
+    const interval = setInterval(fetchLog, 3000); // Refresh every 3s
+    return () => clearInterval(interval);
   }, []);
 
   return (
     <div className="p-4">
-      <h2 className="text-xl font-bold">Agent Log Output</h2>
-      <pre className="bg-black text-green-400 p-2 mt-2">{log}</pre>
+      <h2 className="text-xl font-bold">Agent Log Output (Live)</h2>
+      <pre className="bg-black text-green-400 p-2 mt-2 max-h-[500px] overflow-y-scroll rounded-lg shadow">
+        {log}
+      </pre>
     </div>
   );
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,9 +1,20 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
-import { resolve } from 'path';
+import path, { resolve } from 'path';
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+    },
+  },
+  server: {
+    fs: {
+      allow: ['..'],
+    },
+  },
+  publicDir: 'public',
   css: {
     postcss: resolve(__dirname, 'postcss.config.js'),
   },


### PR DESCRIPTION
## Summary
- unignore public log file
- expose logs through Vite's public dir
- refresh AgentDashboard with polling for `/logs/learning.log`
- add example `public/logs/learning.log` for demo

## Testing
- `npm test`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_685a50c320e88323b6c824540169e20a