### PR TITLE
Add Agent status strip to dashboard

### DIFF
--- a/src/components/AgentDashboard.jsx
+++ b/src/components/AgentDashboard.jsx
@@ -1,14 +1,15 @@
-import { useEffect, useState } from 'react';
-import LogChart from './LogChart';
+import { useEffect, useState } from "react";
+import LogChart from "./LogChart";
+import AgentStatusStrip from "./AgentStatusStrip";
 
 export default function AgentDashboard() {
-  const [log, setLog] = useState('');
+  const [log, setLog] = useState("");
 
   useEffect(() => {
     const fetchLog = () => {
-      fetch('/logs/learning.log')
-        .then(res => res.text())
-        .then(data => setLog(data));
+      fetch("/logs/learning.log")
+        .then((res) => res.text())
+        .then((data) => setLog(data));
     };
 
     fetchLog();
@@ -18,6 +19,7 @@ export default function AgentDashboard() {
 
   return (
     <div className="p-4">
+      <AgentStatusStrip />
       <h2 className="text-xl font-bold">Agent Log Output (Live)</h2>
       <pre className="bg-black text-green-400 p-2 mt-2 max-h-[500px] overflow-y-scroll rounded-lg shadow">
         {log}

--- a/src/components/AgentStatusStrip.jsx
+++ b/src/components/AgentStatusStrip.jsx
@@ -1,0 +1,69 @@
+import { useEffect, useState } from "react";
+
+const thresholds = {
+  latency: { good: 300, warning: 600 },
+  accuracy: { good: 0.9, warning: 0.7 },
+};
+
+function getColor(metric, value) {
+  const t = thresholds[metric] || {};
+  if (metric === "accuracy") {
+    if (value >= t.good) return "bg-green-500";
+    if (value >= t.warning) return "bg-yellow-500";
+    return "bg-red-500";
+  } else {
+    if (value <= t.good) return "bg-green-500";
+    if (value <= t.warning) return "bg-yellow-500";
+    return "bg-red-500";
+  }
+}
+
+export default function AgentStatusStrip() {
+  const [latest, setLatest] = useState([]);
+
+  useEffect(() => {
+    const fetchLog = () => {
+      fetch("/logs/learning.log")
+        .then((res) => res.text())
+        .then((text) => {
+          const lines = text.trim().split("\n");
+          const entries = lines
+            .map((line) => {
+              try {
+                return JSON.parse(line);
+              } catch {
+                return null;
+              }
+            })
+            .filter(Boolean);
+
+          const newestByAgent = {};
+          for (let i = entries.length - 1; i >= 0; i--) {
+            const e = entries[i];
+            if (!newestByAgent[e.agent] && e.value !== undefined) {
+              newestByAgent[e.agent] = e;
+            }
+          }
+
+          setLatest(Object.values(newestByAgent));
+        });
+    };
+
+    fetchLog();
+    const interval = setInterval(fetchLog, 5000);
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <div className="flex gap-2 p-2 bg-gray-900 text-white text-sm overflow-x-auto">
+      {latest.map(({ agent, metric, value }, i) => (
+        <div
+          key={i}
+          className={`rounded px-3 py-1 font-mono ${getColor(metric, value)} text-black`}
+        >
+          {agent}: {metric} = {value}
+        </div>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create `AgentStatusStrip` component for real-time metric updates
- display the status strip in `AgentDashboard`

## Testing
- `npm test`
- `npm run lint` *(fails: existing errors)*
- `npx prettier --check src/components/AgentDashboard.jsx src/components/AgentStatusStrip.jsx`

------
https://chatgpt.com/codex/tasks/task_e_685a564c3e088323bdca0a280e0c771a