### PR TITLE
Set AgentDashboard as default view

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,11 +1,5 @@
 import AgentDashboard from './components/AgentDashboard';
 
-function App() {
-  return (
-    <div className="min-h-screen bg-gray-100 p-6">
-      <h1 className="text-3xl font-bold">AI Agent Systems</h1>
-      <AgentDashboard />
-    </div>
-  );
+export default function App() {
+  return <AgentDashboard />;
 }
-export default App;

--- a/src/Dashboard.jsx
+++ b/src/Dashboard.jsx
@@ -1,5 +1,0 @@
-import React from 'react';
-
-export default function Dashboard() {
-  return <div>Dashboard Placeholder</div>;
-}


### PR DESCRIPTION
## Summary
- make AgentDashboard the root component
- remove unused Dashboard placeholder component

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a5b64c3d48323bd39efe748f0820b