### PR TITLE
Add fake metrics generator

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "agent:absorb-knowledge": "node agentLearningLoop.js",
     "build": "vite build",
     "preview": "vite preview",
-    "check:deps": "node scripts/dependency-checker.js"
+    "check:deps": "node scripts/dependency-checker.js",
+    "generate": "node scripts/generateFakeMetrics.js"
   },
   "keywords": [
     "AI",

--- a/public/logs/learning.log
+++ b/public/logs/learning.log
@@ -1,1 +1,5 @@
-Sample learning log
+{"agent":"beta","metric":"accuracy","value":0.75,"timestamp":"2025-06-24T08:20:26.867Z"}
+{"agent":"alpha","metric":"latency","value":161,"timestamp":"2025-06-24T08:20:35.706Z"}
+{"agent":"gamma","metric":"latency","value":730,"timestamp":"2025-06-24T08:20:46.199Z"}
+{"agent":"gamma","metric":"latency","value":766,"timestamp":"2025-06-24T08:20:54.042Z"}
+{"agent":"beta","metric":"accuracy","value":0.79,"timestamp":"2025-06-24T08:21:02.013Z"}

--- a/scripts/generateFakeMetrics.js
+++ b/scripts/generateFakeMetrics.js
@@ -1,0 +1,31 @@
+const fs = require('fs');
+const path = require('path');
+
+const logPath = path.join(__dirname, '../public/logs/learning.log');
+
+const agents = ['alpha', 'beta', 'gamma'];
+const metrics = ['latency', 'accuracy'];
+
+function getRandomValue(metric) {
+  return metric === 'latency'
+    ? Math.floor(Math.random() * 700 + 100)
+    : Math.random().toFixed(2);
+}
+
+function logSampleData() {
+  const metric = metrics[Math.floor(Math.random() * metrics.length)];
+  const agent = agents[Math.floor(Math.random() * agents.length)];
+  const value = getRandomValue(metric);
+
+  const logEntry = JSON.stringify({
+    agent,
+    metric,
+    value: parseFloat(value),
+    timestamp: new Date().toISOString(),
+  });
+
+  fs.appendFileSync(logPath, logEntry + '\n');
+  console.log('Wrote:', logEntry);
+}
+
+setInterval(logSampleData, 3000); // every 3s


### PR DESCRIPTION
## Summary
- create `scripts/generateFakeMetrics.js` to append random metric entries to `public/logs/learning.log`
- register a `generate` npm script for it
- seed `public/logs/learning.log` with example metric data

## Testing
- `npm test`
- `npm run generate` *(killed after a single entry)*

------
https://chatgpt.com/codex/tasks/task_e_685a5f4df538832383a6dd981ca4d0e5