### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,53 @@
+name: Release
+
+on:
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      GIT_TERMINAL_PROMPT: 0
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - run: npm ci
+
+      - name: Stub Firebase env vars
+        run: |
+          echo "VITE_FIREBASE_API_KEY=${VITE_FIREBASE_API_KEY:-dummy}" >> $GITHUB_ENV
+          echo "VITE_FIREBASE_AUTH_DOMAIN=${VITE_FIREBASE_AUTH_DOMAIN:-dummy}" >> $GITHUB_ENV
+          echo "VITE_FIREBASE_PROJECT_ID=${VITE_FIREBASE_PROJECT_ID:-dummy}" >> $GITHUB_ENV
+        env:
+          VITE_FIREBASE_API_KEY: ${{ secrets.VITE_FIREBASE_API_KEY }}
+          VITE_FIREBASE_AUTH_DOMAIN: ${{ secrets.VITE_FIREBASE_AUTH_DOMAIN }}
+          VITE_FIREBASE_PROJECT_ID: ${{ secrets.VITE_FIREBASE_PROJECT_ID }}
+
+      - name: Bump version and generate changelog
+        run: |
+          git config user.email "github-actions@github.com"
+          git config user.name "github-actions"
+          npx standard-version
+          git push --follow-tags origin main
+
+      - run: npm run build --if-present
+
+      - name: Install Vercel CLI
+        run: npm install -g vercel
+
+      - name: Deploy to Vercel
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: vercel --prod --confirm

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
     "build": "vite build",
     "preview": "vite preview",
     "check:deps": "node scripts/dependency-checker.js",
-    "generate": "node scripts/generateFakeMetrics.js"
+    "generate": "node scripts/generateFakeMetrics.js",
+    "release": "standard-version",
+    "deploy:vercel": "vercel --prod --confirm"
   },
   "keywords": [
     "AI",


### PR DESCRIPTION
## Summary
- add release workflow for semantic versioning, changelog generation and Vercel deployment
- expose `release` and `deploy:vercel` npm scripts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a7363c0c48323970ad0b78ed69146