### PR TITLE
chore: align dev script with vite

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "author": "Csp-Ai",
   "scripts": {
     "start": "node index.js",
-    "dev": "npx vite",
+    "dev": "vite",
     "test": "jest",
     "setup:firebase": "node scripts/firebase-setup.js",
     "deploy": "node scripts/deploy-to-firebase.js",


### PR DESCRIPTION
## Summary
- replace `npx vite` with direct `vite` dev script to match standard Vite workflow
- confirm no `@remix-run/dev` references remain

## Testing
- `npm install`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68917193c6d08323a38f4890b94d9f86