### PR TITLE
chore: ensure Vite build outputs to dist

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -18,4 +18,7 @@ export default defineConfig({
   css: {
     postcss: resolve(__dirname, 'postcss.config.js'),
   },
+  build: {
+    outDir: 'dist',
+  },
 });


### PR DESCRIPTION
## Summary
- specify dist output directory in Vite config
- verified no references to `@remix-run/*`

## Testing
- `npm install`
- `npm run build`
- `grep -R "@remix-run" --exclude-dir=node_modules .`


------
https://chatgpt.com/codex/tasks/task_e_689174a0e94483238980cb2022c4e17b